### PR TITLE
Add set p_nom_min capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ The study is developed as an extension to the PyPSA-Eur model in this repository
 
 Clone the repository including its submodules:
 
-`git clone --recurse-submodules https://github.com/open-energy-transition/heat-demand-peaks`
+    git clone --recurse-submodules https://github.com/open-energy-transition/heat-demand-peaks
 
 Install the necessary dependencies using `conda` or `mamba`:
 
-`mamba env create -f submodules/pypsa-eur/envs/environment.yaml`
+    mamba env create -f submodules/pypsa-eur/envs/environment.yaml
 
 Navigate into the main Snakemake workflow directory of `PyPSA-Eur`:
 
-`cd submodules/pypsa-eur`
+    cd submodules/pypsa-eur
 
 ### 2. Running scenarios
 
 To run the scenarios of a particular configuration file (e.g. `configs/EEE_study/config.flexible-industry.yaml`), run:
 
-`snakemake -call --configfile ../../configs/EEE_study/config.flexible-industry.yaml solve_sector_networks`
+    snakemake -call --configfile ../../configs/EEE_study/config.flexible-industry.yaml solve_sector_networks
 
 This call requires a high-performance computing environment, as well as a [Gurobi license](https://www.gurobi.com/downloads/gurobi-software/).
 
@@ -49,46 +49,46 @@ Please follow the documentation of PyPSA-Eur for more details.
 
 After optimizing scenarios for one horizon, it is important to transfer optimal generation and store capacities into future horizons. To do so, configure `planning_horizon` in `set_capacities` section of `configs/config.plot.yaml`. By default, `2040` is set as `planning_horizon` in `set_capacities`, which helps to transfer `p_nom_opt` values from solved networks of 2030 into `p_nom_min` of corresponding generators and stores of unsolved network of 2040. The optimal capacities are transfered to corresponding scenarios. To set `p_nom_min` for all scenarios of 2040, run:
 
-`snakemake -call set_capacities`
+    snakemake -call set_capacities
 
 * Note! `snakemake` must be run in `heat-demands-peak` base directory (not `pypsa-eur` submodule).
 
 To set minimum capacities for specific scenario (e.g. flexible scenario of 2050 with 48 clusters), you can run run:
 
-`snakemake -call scripts/logs/set_capacities_48_2050_flexible.txt`
+    snakemake -call scripts/logs/set_capacities_48_2050_flexible.txt
 
 ### 4. Plotting
 
 To plot the total system cost for all planning horizons (i.e. 2030, 2040, and 2050) specified in `config.plot.yaml`, run:
 
-`snakemake -call plot_total_costs`
+    snakemake -call plot_total_costs
 
-    Note! The total costs will be plotted only for scenarios where the solved networks are present.
+**Note!** The total costs will be plotted only for scenarios where the solved networks are present.
 
 To plot total costs for specific horizon (e.g. 2040) and number of clusters (e.g. 48), run:
 
-`snakemake -call plots/results/plot_total_costs_48_2040.png`
+    snakemake -call plots/results/plot_total_costs_48_2040.png
 
 To plot electricity bills per household and electricity prices per country for all horizons (i.e. 2030, 2040, and 2050), run:
 
-`snakemake -call plot_electricity_bills`
+    snakemake -call plot_electricity_bills
 
-    Note! The electricity bills and prices will be computed only for scenarios with solved networks.
+**Note!** The electricity bills and prices will be computed only for scenarios with solved networks.
 
 To plot electricity bills separately for specific horizon (e.g. 2040) and number of clusters (e.g. 48), run:
 
-`snakemake -call plots/results/plot_bill_per_household_48_2040.png`
+    snakemake -call plots/results/plot_bill_per_household_48_2040.png
 
 To estimate number of heat pumps and generate table for all horizons and clusters specified in `config.plot.yaml`, run:
 
-`snakemake -call get_heat_pumps`
+    snakemake -call get_heat_pumps
 
 To estimate average grid congestion and generate table for all horizons and clusters specified in `config.plot.yaml`, run:
 
-`snakemake -call get_line_congestions`
+    snakemake -call get_line_congestions
 
 To generate all aforementioned plots and tables at once, run:
 
-`snakemake -call plot_all --forceall`
+    snakemake -call plot_all --forceall
 
-    Note! --forceall flag is used to force a rerun of rule.
+**Note!** --forceall flag is used to force a rerun of rule.

--- a/README.md
+++ b/README.md
@@ -21,17 +21,21 @@ The study is developed as an extension to the PyPSA-Eur model in this repository
 
 # Installation and Usage
 
+### 1. Installation
+
 Clone the repository including its submodules:
 
 `git clone --recurse-submodules https://github.com/open-energy-transition/heat-demand-peaks`
 
 Install the necessary dependencies using `conda` or `mamba`:
 
-`mamba env create -f workflows/pypsa-eur/envs/environment.yaml`
+`mamba env create -f submodules/pypsa-eur/envs/environment.yaml`
 
 Navigate into the main Snakemake workflow directory of `PyPSA-Eur`:
 
-`cd workflows/pypsa-eur`
+`cd submodules/pypsa-eur`
+
+### 2. Running scenarios
 
 To run the scenarios of a particular configuration file (e.g. `configs/EEE_study/config.flexible-industry.yaml`), run:
 
@@ -40,3 +44,51 @@ To run the scenarios of a particular configuration file (e.g. `configs/EEE_study
 This call requires a high-performance computing environment, as well as a [Gurobi license](https://www.gurobi.com/downloads/gurobi-software/).
 
 Please follow the documentation of PyPSA-Eur for more details.
+
+### 3. Transfering optimal capacities to future horizons
+
+After optimizing scenarios for one horizon, it is important to transfer optimal generation and store capacities into future horizons. To do so, configure `planning_horizon` in `set_capacities` section of `configs/config.plot.yaml`. By default, `2040` is set as `planning_horizon` in `set_capacities`, which helps to transfer `p_nom_opt` values from solved networks of 2030 into `p_nom_min` of corresponding generators and stores of unsolved network of 2040. The optimal capacities are transfered to corresponding scenarios. To set `p_nom_min` for all scenarios of 2040, run:
+
+`snakemake -call set_capacities`
+
+* Note! `snakemake` must be run in `heat-demands-peak` base directory (not `pypsa-eur` submodule).
+
+To set minimum capacities for specific scenario (e.g. flexible scenario of 2050 with 48 clusters), you can run run:
+
+`snakemake -call scripts/logs/set_capacities_48_2050_flexible.txt`
+
+### 4. Plotting
+
+To plot the total system cost for all planning horizons (i.e. 2030, 2040, and 2050) specified in `config.plot.yaml`, run:
+
+`snakemake -call plot_total_costs`
+
+    Note! The total costs will be plotted only for scenarios where the solved networks are present.
+
+To plot total costs for specific horizon (e.g. 2040) and number of clusters (e.g. 48), run:
+
+`snakemake -call plots/results/plot_total_costs_48_2040.png`
+
+To plot electricity bills per household and electricity prices per country for all horizons (i.e. 2030, 2040, and 2050), run:
+
+`snakemake -call plot_electricity_bills`
+
+    Note! The electricity bills and prices will be computed only for scenarios with solved networks.
+
+To plot electricity bills separately for specific horizon (e.g. 2040) and number of clusters (e.g. 48), run:
+
+`snakemake -call plots/results/plot_bill_per_household_48_2040.png`
+
+To estimate number of heat pumps and generate table for all horizons and clusters specified in `config.plot.yaml`, run:
+
+`snakemake -call get_heat_pumps`
+
+To estimate average grid congestion and generate table for all horizons and clusters specified in `config.plot.yaml`, run:
+
+`snakemake -call get_line_congestions`
+
+To generate all aforementioned plots and tables at once, run:
+
+`snakemake -call plot_all --forceall`
+
+    Note! --forceall flag is used to force a rerun of rule.

--- a/Snakefile
+++ b/Snakefile
@@ -128,3 +128,15 @@ rule plot_all:
             + "table_line_congestion_{clusters}.csv",
             **config["plotting"],
         ),
+
+rule set_capacities:
+    params:
+        clusters=config["set_capacities"]["clusters"],
+        planning_horizon=config["set_capacities"]["planning_horizon"],
+        scenario=config["set_capacities"]["scenario"]
+    output:
+        logs="scripts/logs/set_capacities_{clusters}_{planning_horizon}_{scenario}.txt",
+    resources:
+        mem_mb=20000,
+    script:
+        "scripts/set_capacities.py"

--- a/Snakefile
+++ b/Snakefile
@@ -129,7 +129,8 @@ rule plot_all:
             **config["plotting"],
         ),
 
-rule set_capacities:
+
+rule set_capacity:
     params:
         clusters=config["set_capacities"]["clusters"],
         planning_horizon=config["set_capacities"]["planning_horizon"],
@@ -140,3 +141,11 @@ rule set_capacities:
         mem_mb=20000,
     script:
         "scripts/set_capacities.py"
+
+
+rule set_capacities:
+    input:
+        expand(
+            "scripts/logs/set_capacities_{clusters}_{planning_horizon}_{scenario}.txt",
+            **config["set_capacities"],
+        ),

--- a/configs/config.plot.yaml
+++ b/configs/config.plot.yaml
@@ -10,3 +10,9 @@ plotting:
 heat_pumps:
   max_capacity: 6900 # https://www.energysage.com/electricity/house-watts/how-many-watts-does-an-air-source-heat-pump-use/
   min_capacity: 830 # https://www.energysage.com/electricity/house-watts/how-many-watts-does-an-air-source-heat-pump-use/
+
+set_capacities:
+  clusters: 48
+  planning_horizon: "2030"
+  time_resolution: "100H"
+  scenario: ["flexible", "retro_tes", "flexible-moderate", "rigid "]

--- a/configs/config.plot.yaml
+++ b/configs/config.plot.yaml
@@ -13,6 +13,6 @@ heat_pumps:
 
 set_capacities:
   clusters: 48
-  planning_horizon: "2030"
+  planning_horizon: "2040" # "2040" (2030->2040), "2050" (2040->2050)
   time_resolution: "100H"
-  scenario: ["flexible", "retro_tes", "flexible-moderate", "rigid "]
+  scenario: ["flexible", "retro_tes", "flexible-moderate", "rigid"]

--- a/plots/_helpers.py
+++ b/plots/_helpers.py
@@ -81,9 +81,14 @@ def update_config_from_wildcards(config, w):
     if w.get("planning_horizon"):
         planning_horizon = w.planning_horizon
         config["plotting"]["planning_horizon"] = planning_horizon
+        config["set_capacities"]["planning_horizon"] = planning_horizon
     if w.get("clusters"):
         clusters = w.clusters
         config["plotting"]["clusters"] = clusters
+        config["set_capacities"]["clusters"] = clusters
+    if w.get("scenario"):
+        scenario = w.scenario
+        config["set_capacities"]["scenario"] = scenario
     return config
 
 
@@ -96,6 +101,23 @@ def load_network(lineex, clusters, sector_opts, planning_horizon, scenario):
         print(f"Error: {e}")
         return None
     return n
+
+
+def load_unsolved_network(lineex, clusters, sector_opts, planning_horizon, scenario):
+    FILE = f"elec_s_{clusters}_l{lineex}__{sector_opts}_{planning_horizon}.nc"
+    DIR = f"results/{scenario}/prenetworks"
+    try:
+        n = pypsa.Network(os.path.join(DIR, FILE))
+    except FileNotFoundError as e:
+        print(f"Error: {e}")
+        return None
+    return n
+
+
+def save_unsolved_network(network, lineex, clusters, sector_opts, planning_horizon, scenario):
+    FILE = f"elec_s_{clusters}_l{lineex}__{sector_opts}_{planning_horizon}.nc"
+    DIR = f"results/{scenario}/prenetworks/"
+    network.export_to_netcdf(DIR+FILE)
 
 
 def change_path_to_pypsa_eur():

--- a/scripts/set_capacities.py
+++ b/scripts/set_capacities.py
@@ -6,10 +6,52 @@ import pandas as pd
 import logging
 import warnings
 warnings.filterwarnings("ignore")
-print(os.getcwd())
-print(sys.path)
 from plots._helpers import mock_snakemake, update_config_from_wildcards, load_network, \
-                    change_path_to_pypsa_eur, change_path_to_base
+                    change_path_to_pypsa_eur, change_path_to_base, load_unsolved_network, \
+                    save_unsolved_network
+
+
+def get_capacities(network, capacity="opt"):
+    # extendable generators and capacities
+    ext_gen = network.generators.query("p_nom_extendable==True")
+    ext_gen_cap = ext_gen["p_nom_"+capacity]
+    
+    # extendable stores and capacities
+    ext_store = network.stores.query("e_nom_extendable==True")
+    ext_store_cap = ext_store["e_nom_"+capacity]
+
+    return ext_gen_cap, ext_store_cap
+
+
+def get_common_index(list1, list2):
+    # get common index
+    common_index = set(list1).intersection(set(list2))
+    return common_index
+
+
+def set_optimal_capacities(solved_network, unsolved_network):
+    # get optimal capacities from previous horizon
+    opt_gen_cap, opt_store_cap = get_capacities(solved_network, "opt")
+
+    # get minimum capacities from planned horizon
+    min_gen_cap, min_store_cap = get_capacities(unsolved_network, "min")
+
+    # get common extendable generators and stores
+    common_gen = get_common_index(opt_gen_cap.index, min_gen_cap.index)
+    common_store = get_common_index(opt_store_cap.index, min_store_cap.index)
+
+    # remove generators with coal, gas, and oil carriers
+    fossil_carriers = ["coal", "oil", "gas", "co2", "co2 stored", "co2 sequestered"]
+    fossil_gens = unsolved_network.generators.query("carrier in @fossil_carriers").index
+    fossil_stores = unsolved_network.stores.query("carrier in @fossil_carriers").index
+    target_gens = list(set(common_gen).difference(set(fossil_gens)))
+    target_stores = list(set(common_store).difference(set(fossil_stores)))
+
+    # set p_nom_min and e_nom_min capacities
+    unsolved_network.generators.loc[target_gens, "p_nom_min"] = opt_gen_cap[target_gens]
+    unsolved_network.stores.loc[target_stores, "e_nom_min"] = opt_store_cap[target_stores]
+
+    return unsolved_network
 
 
 if __name__ == "__main__":
@@ -17,16 +59,18 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "set_capacities", 
             clusters="48",
-            planning_horizon="2030",
+            planning_horizon="2040",
             scenario="flexible"
         )
     # update config based on wildcards
     config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
 
-
-    # network parameters
+    # network parameters by year
     co2l_limits = {"2030":"0.45", "2040":"0.1", "2050":"0.0"}
     line_limits = {"2030":"v1.15", "2040":"v1.3", "2050":"v1.5"}
+    previous_horizons = {"2040":"2030", "2050":"2040"} 
+
+    # network parameters of unsolved network
     clusters = config["set_capacities"]["clusters"]
     planning_horizon = config["set_capacities"]["planning_horizon"]
     time_resolution = config["set_capacities"]["time_resolution"]
@@ -34,18 +78,38 @@ if __name__ == "__main__":
     lineex = line_limits[planning_horizon]
     sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-T-H-B-I"
 
+    # network parameters of solved network
+    previous_horizon = previous_horizons[planning_horizon]
+    previous_lineex = line_limits[previous_horizon]
+    previous_sector_opts = f"Co2L{co2l_limits[previous_horizon]}-{time_resolution}-T-H-B-I"
+
     # move to pypsa-eur directory
     change_path_to_pypsa_eur()
 
     # load solved network
-    solved_network = load_network(lineex, clusters, sector_opts, planning_horizon, scenario)
+    solved_network = load_network(previous_lineex, clusters, previous_sector_opts, previous_horizon, scenario)
     
-    
+    # load unsolved network for future
+    unsolved_network = load_unsolved_network(lineex, clusters, sector_opts, planning_horizon, scenario)
 
+    # if both network is present, then set optimal capacities
+    if not solved_network is None and not unsolved_network is None:
+        updated_network = set_optimal_capacities(solved_network, unsolved_network)
+        print(f"Updated: {lineex}, {clusters}, {sector_opts}, {planning_horizon}, {scenario}")
+        # save updated network
+        try:
+            save_unsolved_network(updated_network, lineex, clusters, sector_opts, planning_horizon, scenario)
+            success = True
+        except Exception as e:
+            print(f"Error: {e}")
+            success = False
 
     # move to base directory
     change_path_to_base()
 
     # write logs
     with open(snakemake.output.logs, 'w') as f:
-        f.write("Done")
+        f.write(f"""Scenarios: {scenario} 
+                \nPlanning horizon: {planning_horizon} 
+                \nClusters: {clusters} 
+                \nSuccess: {success}""")

--- a/scripts/set_capacities.py
+++ b/scripts/set_capacities.py
@@ -1,0 +1,51 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(__file__ ,"../../")))
+import pypsa
+import pandas as pd
+import logging
+import warnings
+warnings.filterwarnings("ignore")
+print(os.getcwd())
+print(sys.path)
+from plots._helpers import mock_snakemake, update_config_from_wildcards, load_network, \
+                    change_path_to_pypsa_eur, change_path_to_base
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        snakemake = mock_snakemake(
+            "set_capacities", 
+            clusters="48",
+            planning_horizon="2030",
+            scenario="flexible"
+        )
+    # update config based on wildcards
+    config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
+
+
+    # network parameters
+    co2l_limits = {"2030":"0.45", "2040":"0.1", "2050":"0.0"}
+    line_limits = {"2030":"v1.15", "2040":"v1.3", "2050":"v1.5"}
+    clusters = config["set_capacities"]["clusters"]
+    planning_horizon = config["set_capacities"]["planning_horizon"]
+    time_resolution = config["set_capacities"]["time_resolution"]
+    scenario = config["set_capacities"]["scenario"]
+    lineex = line_limits[planning_horizon]
+    sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-T-H-B-I"
+
+    # move to pypsa-eur directory
+    change_path_to_pypsa_eur()
+
+    # load solved network
+    solved_network = load_network(lineex, clusters, sector_opts, planning_horizon, scenario)
+    
+    
+
+
+    # move to base directory
+    change_path_to_base()
+
+    # write logs
+    with open(snakemake.output.logs, 'w') as f:
+        f.write("Done")


### PR DESCRIPTION
Good day. Here, I propose an update to incorporate `p_nom_min` update based on `p_nom_opt` of previous horizon. There is a rule `set_capacities` that will update all unsolved networks for `flexible`, `retro_tes`, `flexible-moderate` and `rigid` scenarios.