### PR TITLE
Update moderate_retrofitting parameters using wildcards

### DIFF
--- a/plots/_helpers.py
+++ b/plots/_helpers.py
@@ -82,10 +82,12 @@ def update_config_from_wildcards(config, w):
         planning_horizon = w.planning_horizon
         config["plotting"]["planning_horizon"] = planning_horizon
         config["set_capacities"]["planning_horizon"] = planning_horizon
+        config["moderate_retrofitting"]["planning_horizon"] = planning_horizon
     if w.get("clusters"):
         clusters = w.clusters
         config["plotting"]["clusters"] = clusters
         config["set_capacities"]["clusters"] = clusters
+        config["moderate_retrofitting"]["clusters"] = clusters
     if w.get("scenario"):
         scenario = w.scenario
         config["set_capacities"]["scenario"] = scenario


### PR DESCRIPTION
Good day. Here, I propose to update _helpers, so that the wildcards can be used to update the `moderate_retrofitting` parameters in `config.plot.yaml`.