### PR TITLE
add outputs of total costs to avoid missing file error

### DIFF
--- a/plots/plot_total_costs.py
+++ b/plots/plot_total_costs.py
@@ -287,7 +287,6 @@ def plot_capacities(caps_df, clusters, planning_horizon):
 
     new_columns = df.sum().sort_values().index  
 
-
     fig, ax = plt.subplots(figsize=(7, 9))
 
     df.loc[new_index].T.plot(
@@ -467,7 +466,11 @@ if __name__ == "__main__":
         # plot costs
         if not cost_df.empty:
             plot_costs(cost_df, clusters, planning_horizon)
+            f = open(snakemake.output.costs, "w")
+            f.close()
 
         # plot capacities
         if not capacities_df.empty:
             plot_capacities(capacities_df, clusters, planning_horizon)
+            f = open(snakemake.output.capacities, "w")
+            f.close()


### PR DESCRIPTION
@yerbol-akhmetov  currently the total costs script never writes the snakemake outputs, which leads to an error.

I added a hot fix, but would you mind updating it such that the output is a .csv file and also writes the total costs / capacities not only as a .png, but also as a table? Would be good if the name of the .png is also the snakemake output, and not hard coded within the script

Thanks! :)