### PR TITLE
Update plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,17 @@ Install the necessary dependencies using `conda` or `mamba`:
 
     mamba env create -f submodules/pypsa-eur/envs/environment.yaml
 
+Activate `pypsa-eur` environment:
+
+    conda activate pypsa-eur
+
 Navigate into the main Snakemake workflow directory of `PyPSA-Eur`:
 
     cd submodules/pypsa-eur
 
 ### 2. Running scenarios
+
+#### A. Running individual scenario
 
 To run the scenarios of a particular configuration file (e.g. `configs/EEE_study/config.flexible-industry.yaml`), run:
 
@@ -45,15 +51,24 @@ This call requires a high-performance computing environment, as well as a [Gurob
 
 Please follow the documentation of PyPSA-Eur for more details.
 
-### 3. Setting nominal capacities of retrofitting for `Limited Renovation & Optimal Heating` scenario
+#### B. Running scenario for several horizons
 
-The nominal capacities of retrofitting for `Limited Renovation & Optimal Heating` (moderate retrofitting) scenario is set by running:
+To run the scenario for several horizons at once (e.g. *Optimal Renovation & Heating* scenario), run:
+
+    python scripts/run.py -s flexible -c 2040
+
+Using `-s` flag, the scenario is selected. `-c` flag (optional) speficies from which planning horizon the simulation should start. So if `-c 2040` is given, then 2040 and 2050 horizons will be simulated consequitively; if not specified, then 2030 is used as a starting year by default. `-c` flag is useful when simulation is interupted and it needs to be re-run from certain horizon.
+**Note!** To run *Limited Renovation & Optimal Heating* (`flexible-moderate`) scenario, *Optimal Renovation & Heating* (`flexible`) scenario needs to be run first.
+
+#### C. Setting nominal capacities of retrofitting for *Limited Renovation & Optimal Heating* scenario
+
+The nominal capacities of retrofitting for *Limited Renovation & Optimal Heating* (flexible-moderate) scenario is set by running:
 
     snakemake -call set_moderate_retrofitting
 
 * Note! This and the following `snakemake` commands must be run in `heat-demands-peak` base directory (not `pypsa-eur` submodule).
 
-This command will set `p_nom` for moderate retrofitting network as a half of `p_nom_opt` of solved `Optimal Renovation and Heating` (flexible) scenario. The network parameters, such as `clusters`, `planning_horizon`, and `time_resolution`, are defined in `moderate_retrofitting` section of `configs/config.plot.yaml`. 
+This command will set `p_nom` for moderate retrofitting network as a half of `p_nom_opt` of solved *Optimal Renovation and Heating* (flexible) scenario. The network parameters, such as `clusters`, `planning_horizon`, and `time_resolution`, are defined in `moderate_retrofitting` section of `configs/config.plot.yaml`. 
 
 As an alternative, the nominal capacities for moderate retrofitting scenario can be set by running the command with wildcards (e.g. scenario for 2030 with 48 clusters):
 
@@ -61,7 +76,7 @@ As an alternative, the nominal capacities for moderate retrofitting scenario can
 
 The resultant file in `scripts/logs/set_moderate_retrofitting_48_2030.txt` contains `Success` parameter which indicates the success status of executed rule. Here, `--force` flag is used to forcefully re-execute the rule.
 
-### 4. Transfering optimal capacities to future horizons
+#### D. Transfering optimal capacities to future horizons
 
 After optimizing scenarios for one horizon, it is important to transfer optimal generation and store capacities into future horizons. To do so, configure `planning_horizon` in `set_capacities` section of `configs/config.plot.yaml`. By default, `2040` is set as `planning_horizon` in `set_capacities`, which helps to transfer `p_nom_opt` values from solved networks of 2030 into `p_nom_min` of corresponding generators and stores of unsolved network of 2040. The optimal capacities are transfered to corresponding scenarios. To set `p_nom_min` for all scenarios of 2040, run:
 
@@ -73,7 +88,7 @@ To set minimum capacities for specific scenario (e.g. flexible scenario of 2050 
 
 The resultant file in `scripts/logs/set_capacities_48_2050_flexible.txt` contains `Success` parameter which indicates the success status of executed rule.
 
-### 5. Plotting
+### 3. Plotting
 
 To plot the total system cost for all planning horizons (i.e. 2030, 2040, and 2050) specified in `config.plot.yaml`, run:
 

--- a/Snakefile
+++ b/Snakefile
@@ -199,7 +199,6 @@ rule plot_co2_level:
     params:
         clusters=config["plotting"]["clusters"],
     output:
-        figure=RESULTS+"plot_co2_level_{clusters}.png",
         table=RESULTS+"table_co2_level_{clusters}.csv",
     resources:
         mem_mb=20000,
@@ -209,11 +208,6 @@ rule plot_co2_level:
 
 rule plot_co2_levels:
     input:
-        expand(
-            RESULTS
-            + "plot_co2_level_{clusters}.png",
-            **config["plotting"],
-        ),
         expand(
             RESULTS
             + "table_co2_level_{clusters}.csv",
@@ -336,11 +330,6 @@ rule plot_all:
         expand(
             RESULTS
             + "plot_COP.png",
-            **config["plotting"],
-        ),
-        expand(
-            RESULTS
-            + "plot_co2_level_{clusters}.png",
             **config["plotting"],
         ),
         expand(

--- a/Snakefile
+++ b/Snakefile
@@ -195,6 +195,32 @@ rule plot_COP:
         "plots/plot_COP.py"
 
 
+rule plot_co2_level:
+    params:
+        clusters=config["plotting"]["clusters"],
+    output:
+        figure=RESULTS+"plot_co2_level_{clusters}.png",
+        table=RESULTS+"table_co2_level_{clusters}.csv",
+    resources:
+        mem_mb=20000,
+    script:
+        "plots/plot_co2_level.py"
+
+
+rule plot_co2_levels:
+    input:
+        expand(
+            RESULTS
+            + "plot_co2_level_{clusters}.png",
+            **config["plotting"],
+        ),
+        expand(
+            RESULTS
+            + "table_co2_level_{clusters}.csv",
+            **config["plotting"],
+        ),
+
+
 rule get_heat_pump:
     params:
         clusters=config["plotting"]["clusters"],
@@ -310,6 +336,16 @@ rule plot_all:
         expand(
             RESULTS
             + "plot_COP.png",
+            **config["plotting"],
+        ),
+        expand(
+            RESULTS
+            + "plot_co2_level_{clusters}.png",
+            **config["plotting"],
+        ),
+        expand(
+            RESULTS
+            + "table_co2_level_{clusters}.csv",
             **config["plotting"],
         ),
         expand(

--- a/Snakefile
+++ b/Snakefile
@@ -133,6 +133,38 @@ rule plot_curtailments:
         ),
 
 
+rule plot_hydrogen_production:
+    params:
+        clusters=config["plotting"]["clusters"],
+    output:
+        figure_elec=RESULTS+"plot_H2_prod_elec_use_{clusters}.png",
+        figure_prod=RESULTS+"plot_H2_prod_{clusters}.png",
+        table=RESULTS+"table_H2_prod_{clusters}.csv",
+    resources:
+        mem_mb=20000,
+    script:
+        "plots/plot_hydrogen_production.py"
+
+
+rule plot_hydrogen_productions:
+    input:
+        expand(
+            RESULTS
+            + "plot_H2_prod_elec_use_{clusters}.png",
+            **config["plotting"],
+        ),
+        expand(
+            RESULTS
+            + "plot_H2_prod_{clusters}.png",
+            **config["plotting"],
+        ),
+        expand(
+            RESULTS
+            + "table_H2_prod_{clusters}.csv",
+            **config["plotting"],
+        ),
+
+
 rule get_heat_pump:
     params:
         clusters=config["plotting"]["clusters"],
@@ -233,6 +265,21 @@ rule plot_all:
         expand(
             RESULTS
             + "table_curtailment_{clusters}.csv",
+            **config["plotting"],
+        ),
+        expand(
+            RESULTS
+            + "plot_H2_prod_elec_use_{clusters}.png",
+            **config["plotting"],
+        ),
+        expand(
+            RESULTS
+            + "plot_H2_prod_{clusters}.png",
+            **config["plotting"],
+        ),
+        expand(
+            RESULTS
+            + "table_H2_prod_{clusters}.csv",
             **config["plotting"],
         ),
 

--- a/Snakefile
+++ b/Snakefile
@@ -165,6 +165,27 @@ rule plot_hydrogen_productions:
         ),
 
 
+rule plot_heat_tech_ratio:
+    params:
+        clusters=config["plotting"]["clusters"],
+        planning_horizon=config["plotting"]["planning_horizon"],
+    output:
+        table=RESULTS+"table_heat_tech_ratio_{clusters}.csv",
+    resources:
+        mem_mb=20000,
+    script:
+        "plots/plot_heat_tech_ratio.py"
+
+
+rule plot_heat_tech_ratios:
+    input:
+        expand(
+            RESULTS
+            + "table_heat_tech_ratio_{clusters}.csv",
+            **config["plotting"],
+        ),
+
+
 rule get_heat_pump:
     params:
         clusters=config["plotting"]["clusters"],
@@ -280,6 +301,11 @@ rule plot_all:
         expand(
             RESULTS
             + "table_H2_prod_{clusters}.csv",
+            **config["plotting"],
+        ),
+        expand(
+            RESULTS
+            + "table_heat_tech_ratio_{clusters}.csv",
             **config["plotting"],
         ),
 

--- a/Snakefile
+++ b/Snakefile
@@ -77,6 +77,15 @@ rule plot_electricity_bills:
         ),
 
 
+rule plot_electricity_for_heats:
+    input:
+        expand(
+            RESULTS
+            + "plot_electricity_for_heat_{clusters}_{planning_horizon}.png",
+            **config["plotting"],
+        ),
+
+
 rule plot_electricity_generation:
     params:
         clusters=config["plotting"]["clusters"],

--- a/Snakefile
+++ b/Snakefile
@@ -186,6 +186,15 @@ rule plot_heat_tech_ratios:
         ),
 
 
+rule plot_COP:
+    output:
+        figure=RESULTS+"plot_COP.png",
+    resources:
+        mem_mb=20000,
+    script:
+        "plots/plot_COP.py"
+
+
 rule get_heat_pump:
     params:
         clusters=config["plotting"]["clusters"],
@@ -296,6 +305,11 @@ rule plot_all:
         expand(
             RESULTS
             + "plot_H2_prod_{clusters}.png",
+            **config["plotting"],
+        ),
+        expand(
+            RESULTS
+            + "plot_COP.png",
             **config["plotting"],
         ),
         expand(

--- a/configs/EEE_study/config.BAU.yaml
+++ b/configs/EEE_study/config.BAU.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 38.84
     CCGT: 38.84
     gas: 38.84
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 280650
     "decentral solar thermal": 428920

--- a/configs/EEE_study/config.BAU.yaml
+++ b/configs/EEE_study/config.BAU.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.7-100H-dist1.1-T-H-B-I
+  - Co2L0.7-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2020
 
@@ -48,7 +48,8 @@ sector:
   residential_heat_dsm: false
   cluster_heat_buses: false
   retrofitting:
-    retro_endogen: false #true 
+    retro_endogen: false #true
+    WWHR_endogen: false # Waste Water Heat Recovery
   tes: false #true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.BAU.yaml
+++ b/configs/EEE_study/config.BAU.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.7-12H-dist1.1-T-H-B-I
+  - Co2L0.7-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2020
 
@@ -47,6 +47,7 @@ sector:
       2020: 0.0
   residential_heat_dsm: false
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
     retro_endogen: false #true
     WWHR_endogen: false # Waste Water Heat Recovery

--- a/configs/EEE_study/config.flexible-industry_2030.yaml
+++ b/configs/EEE_study/config.flexible-industry_2030.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.45-12H-dist1.1-T-H-B-I
+  - Co2L0.45-3H-dist1.1-T-H-B-I
 
   planning_horizons:
   - 2030
@@ -49,8 +49,10 @@ sector:
   residential_heat_dsm: true
   residential_heat_restriction_value: 0.27
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: true 
+    retro_endogen: true
+    WWHR_endogen: true
   tes: true
   boilers: true
   biomass_boiler: false

--- a/configs/EEE_study/config.flexible-industry_2030.yaml
+++ b/configs/EEE_study/config.flexible-industry_2030.yaml
@@ -89,6 +89,10 @@ costs:
     OCGT: 38.84
     CCGT: 38.84
     gas: 38.84
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 280650
     "decentral solar thermal": 428920

--- a/configs/EEE_study/config.flexible-industry_2030.yaml
+++ b/configs/EEE_study/config.flexible-industry_2030.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.45-100H-dist1.1-T-H-B-I
+  - Co2L0.45-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2030
 
@@ -46,7 +46,7 @@ sector:
     progress:
       2030: 0.3
   residential_heat_dsm: true
-  residential_heat_restriction_value: 0.05
+  residential_heat_restriction_value: 0.27
   cluster_heat_buses: false
   retrofitting:
     retro_endogen: true 

--- a/configs/EEE_study/config.flexible-industry_2040.yaml
+++ b/configs/EEE_study/config.flexible-industry_2040.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.1-100H-dist1.1-T-H-B-I
+  - Co2L0.1-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2040
 

--- a/configs/EEE_study/config.flexible-industry_2040.yaml
+++ b/configs/EEE_study/config.flexible-industry_2040.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.1-12H-dist1.1-T-H-B-I
+  - Co2L0.1-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2040
 
@@ -48,8 +48,10 @@ sector:
   residential_heat_dsm: true
   residential_heat_restriction_value: 0.2
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: true 
+    retro_endogen: true
+    WWHR_endogen: true
   tes: true
   boilers: true
   biomass_boiler: false

--- a/configs/EEE_study/config.flexible-industry_2040.yaml
+++ b/configs/EEE_study/config.flexible-industry_2040.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 38.84
     CCGT: 38.84
     gas: 38.84
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 196455
     "decentral solar thermal": 300245

--- a/configs/EEE_study/config.flexible-industry_2050.yaml
+++ b/configs/EEE_study/config.flexible-industry_2050.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.0-12H-dist1.1-T-H-B-I
+  - Co2L0.0-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2050
 
@@ -48,8 +48,10 @@ sector:
   residential_heat_dsm: true
   residential_heat_restriction_value: 0.6
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: true 
+    retro_endogen: true
+    WWHR_endogen: true
   tes: true
   boilers: true
   biomass_boiler: false

--- a/configs/EEE_study/config.flexible-industry_2050.yaml
+++ b/configs/EEE_study/config.flexible-industry_2050.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 42.08
     CCGT: 42.08
     gas: 42.08
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 112260
     "decentral solar thermal": 171570

--- a/configs/EEE_study/config.flexible-industry_2050.yaml
+++ b/configs/EEE_study/config.flexible-industry_2050.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.0-100H-dist1.1-T-H-B-I
+  - Co2L0.0-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2050
 

--- a/configs/EEE_study/config.flexible-moderate_2030.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2030.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 38.84
     CCGT: 38.84
     gas: 38.84
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 280650
     "decentral solar thermal": 428920

--- a/configs/EEE_study/config.flexible-moderate_2030.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2030.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.45-12H-dist1.1-T-H-B-I
+  - Co2L0.45-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2030
 
@@ -48,8 +48,10 @@ sector:
   residential_heat_dsm: true
   residential_heat_restriction_value: 0.135
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: true 
+    retro_endogen: true
+    WWHR_endogen: true
   tes: true
   boilers: true
   biomass_boiler: false

--- a/configs/EEE_study/config.flexible-moderate_2030.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2030.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.45-100H-dist1.1-T-H-B-I
+  - Co2L0.45-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2030
 
@@ -46,7 +46,7 @@ sector:
     progress:
       2030: 0.3
   residential_heat_dsm: true
-  residential_heat_restriction_value: 0.025
+  residential_heat_restriction_value: 0.135
   cluster_heat_buses: false
   retrofitting:
     retro_endogen: true 

--- a/configs/EEE_study/config.flexible-moderate_2040.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2040.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.1-100H-dist1.1-T-H-B-I
+  - Co2L0.1-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2040
 

--- a/configs/EEE_study/config.flexible-moderate_2040.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2040.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.1-12H-dist1.1-T-H-B-I
+  - Co2L0.1-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2040
 
@@ -48,8 +48,10 @@ sector:
   residential_heat_dsm: true
   residential_heat_restriction_value: 0.1
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: true 
+    retro_endogen: true
+    WWHR_endogen: true
   tes: true
   boilers: true
   biomass_boiler: false

--- a/configs/EEE_study/config.flexible-moderate_2040.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2040.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 38.84
     CCGT: 38.84
     gas: 38.84
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 196455
     "decentral solar thermal": 300245

--- a/configs/EEE_study/config.flexible-moderate_2040.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2040.yaml
@@ -55,7 +55,7 @@ sector:
     retro_endogen: true
     WWHR_endogen: true
   tes: true
-  boilers: true
+  boilers: false
   biomass_boiler: false
   micro_chp: true
   regional_coal_demand: true

--- a/configs/EEE_study/config.flexible-moderate_2050.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2050.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.0-12H-dist1.1-T-H-B-I
+  - Co2L0.0-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2050
 
@@ -48,8 +48,10 @@ sector:
   residential_heat_dsm: true
   residential_heat_restriction_value: 0.3
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: true 
+    retro_endogen: true
+    WWHR_endogen: true
   tes: true
   boilers: true
   biomass_boiler: false

--- a/configs/EEE_study/config.flexible-moderate_2050.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2050.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 42.08
     CCGT: 42.08
     gas: 42.08
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 112260
     "decentral solar thermal": 171570

--- a/configs/EEE_study/config.flexible-moderate_2050.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2050.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.0-100H-dist1.1-T-H-B-I
+  - Co2L0.0-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2050
 

--- a/configs/EEE_study/config.flexible-moderate_2050.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2050.yaml
@@ -55,7 +55,7 @@ sector:
     retro_endogen: true
     WWHR_endogen: true
   tes: true
-  boilers: true
+  boilers: false
   biomass_boiler: false
   micro_chp: true
   regional_coal_demand: true

--- a/configs/EEE_study/config.retro_tes-industry_2030.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2030.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 38.84
     CCGT: 38.84
     gas: 38.84
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 280650
     "decentral solar thermal": 428920

--- a/configs/EEE_study/config.retro_tes-industry_2030.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2030.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.45-100H-dist1.1-T-H-B-I
+  - Co2L0.45-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2030
 
@@ -46,7 +46,7 @@ sector:
     progress:
       2030: 0.3
   residential_heat_dsm: true
-  residential_heat_restriction_value: 0.05
+  residential_heat_restriction_value: 0.27
   cluster_heat_buses: false
   retrofitting:
     retro_endogen: true 

--- a/configs/EEE_study/config.retro_tes-industry_2030.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2030.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.45-12H-dist1.1-T-H-B-I
+  - Co2L0.45-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2030
 
@@ -48,8 +48,10 @@ sector:
   residential_heat_dsm: true
   residential_heat_restriction_value: 0.27
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: true 
+    retro_endogen: true
+    WWHR_endogen: true
   tes: true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.retro_tes-industry_2040.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2040.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.1-100H-dist1.1-T-H-B-I
+  - Co2L0.1-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2040
 

--- a/configs/EEE_study/config.retro_tes-industry_2040.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2040.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 38.84
     CCGT: 38.84
     gas: 38.84
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 196455
     "decentral solar thermal": 300245

--- a/configs/EEE_study/config.retro_tes-industry_2040.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2040.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.1-12H-dist1.1-T-H-B-I
+  - Co2L0.1-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2040
 
@@ -48,8 +48,10 @@ sector:
   residential_heat_dsm: true
   residential_heat_restriction_value: 0.2
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: true 
+    retro_endogen: true
+    WWHR_endogen: true
   tes: true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.retro_tes-industry_2050.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2050.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 42.08
     CCGT: 42.08
     gas: 42.08
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 112260
     "decentral solar thermal": 171570

--- a/configs/EEE_study/config.retro_tes-industry_2050.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2050.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.0-100H-dist1.1-T-H-B-I
+  - Co2L0.0-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2050
 

--- a/configs/EEE_study/config.retro_tes-industry_2050.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2050.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.0-12H-dist1.1-T-H-B-I
+  - Co2L0.0-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2050
 
@@ -48,8 +48,10 @@ sector:
   residential_heat_dsm: true
   residential_heat_restriction_value: 0.6
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: true 
+    retro_endogen: true
+    WWHR_endogen: true
   tes: true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.rigid-industry_2030.yaml
+++ b/configs/EEE_study/config.rigid-industry_2030.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 38.84
     CCGT: 38.84
     gas: 38.84
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 280650
     "decentral solar thermal": 428920

--- a/configs/EEE_study/config.rigid-industry_2030.yaml
+++ b/configs/EEE_study/config.rigid-industry_2030.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.45-100H-dist1.1-T-H-B-I
+  - Co2L0.45-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2030
 
@@ -48,7 +48,8 @@ sector:
   residential_heat_dsm: false
   cluster_heat_buses: false
   retrofitting:
-    retro_endogen: false #true 
+    retro_endogen: false #true
+    WWHR_endogen: false # Waste Water Heat Recovery
   tes: false #true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.rigid-industry_2030.yaml
+++ b/configs/EEE_study/config.rigid-industry_2030.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.45-12H-dist1.1-T-H-B-I
+  - Co2L0.45-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2030
 
@@ -47,9 +47,10 @@ sector:
       2030: 0.3
   residential_heat_dsm: false
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: false #true
-    WWHR_endogen: false # Waste Water Heat Recovery
+    retro_endogen: false
+    WWHR_endogen: false
   tes: false #true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.rigid-industry_2040.yaml
+++ b/configs/EEE_study/config.rigid-industry_2040.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.1-12H-dist1.1-T-H-B-I
+  - Co2L0.1-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2040
 
@@ -47,9 +47,10 @@ sector:
       2040: 0.6
   residential_heat_dsm: false
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: false #true
-    WWHR_endogen: false # Waste Water Heat Recovery
+    retro_endogen: false
+    WWHR_endogen: false
   tes: false #true
   boilers: false #true
   biomass_boiler: false
@@ -70,7 +71,7 @@ sector:
     2040: 0.6
   land_transport_ice_share:
     2040: 0.3
-    reduce_hot_water_factor:
+  reduce_hot_water_factor:
     2040: 0
   conventional_generation:
     OCGT: gas

--- a/configs/EEE_study/config.rigid-industry_2040.yaml
+++ b/configs/EEE_study/config.rigid-industry_2040.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 38.84
     CCGT: 38.84
     gas: 38.84
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 196455
     "decentral solar thermal": 300245

--- a/configs/EEE_study/config.rigid-industry_2040.yaml
+++ b/configs/EEE_study/config.rigid-industry_2040.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.1-100H-dist1.1-T-H-B-I
+  - Co2L0.1-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2040
 
@@ -48,7 +48,8 @@ sector:
   residential_heat_dsm: false
   cluster_heat_buses: false
   retrofitting:
-    retro_endogen: false #true 
+    retro_endogen: false #true
+    WWHR_endogen: false # Waste Water Heat Recovery
   tes: false #true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.rigid-industry_2050.yaml
+++ b/configs/EEE_study/config.rigid-industry_2050.yaml
@@ -88,6 +88,10 @@ costs:
     OCGT: 42.08
     CCGT: 42.08
     gas: 42.08
+    coal: 24.57
+    lignite: 22.11
+    nuclear: 1.75
+    uranium: 1.75
   investment:
     "central solar thermal": 112260
     "decentral solar thermal": 171570

--- a/configs/EEE_study/config.rigid-industry_2050.yaml
+++ b/configs/EEE_study/config.rigid-industry_2050.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.0-12H-dist1.1-T-H-B-I
+  - Co2L0.0-3H-dist1.1-T-H-B-I
   planning_horizons:
   - 2050
 
@@ -47,9 +47,10 @@ sector:
       2050: 1.0
   residential_heat_dsm: false
   cluster_heat_buses: false
+  reduce_space_heat_exogenously: false
   retrofitting:
-    retro_endogen: false # true
-    WWHR_endogen: false # Waste Water Heat Recovery
+    retro_endogen: false
+    WWHR_endogen: false
   tes: false # true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.rigid-industry_2050.yaml
+++ b/configs/EEE_study/config.rigid-industry_2050.yaml
@@ -11,7 +11,7 @@ scenario:
   clusters:
   - 48
   sector_opts:
-  - Co2L0.0-100H-dist1.1-T-H-B-I
+  - Co2L0.0-12H-dist1.1-T-H-B-I
   planning_horizons:
   - 2050
 
@@ -48,7 +48,8 @@ sector:
   residential_heat_dsm: false
   cluster_heat_buses: false
   retrofitting:
-    retro_endogen: false # true 
+    retro_endogen: false # true
+    WWHR_endogen: false # Waste Water Heat Recovery
   tes: false # true
   boilers: false #true
   biomass_boiler: false

--- a/configs/config.plot.yaml
+++ b/configs/config.plot.yaml
@@ -6,7 +6,7 @@ plotting:
   clusters: 48
   planning_horizon: [2020, 2030, 2040, 2050]
   time_resolution: "12H"
-  sector_opts: "T-H-B-I"
+  sector_opts: "dist1.1-T-H-B-I"
 
 heat_pumps:
   residential_decentral: 7.5 # (kW_el) https://iea.blob.core.windows.net/assets/4713780d-c0ae-4686-8c9b-29e782452695/TheFutureofHeatPumps.pdf
@@ -18,10 +18,10 @@ set_capacities:
   planning_horizon: "2040" # "2040" (2030->2040), "2050" (2040->2050)
   time_resolution: "12H"
   scenario: ["flexible", "retro_tes", "flexible-moderate", "rigid"]
-  sector_opts: "T-H-B-I"
+  sector_opts: "dist1.1-T-H-B-I"
 
 moderate_retrofitting:
   clusters: 48
   planning_horizon: "2030"
   time_resolution: "12H"
-  sector_opts: "T-H-B-I"
+  sector_opts: "dist1.1-T-H-B-I"

--- a/configs/config.plot.yaml
+++ b/configs/config.plot.yaml
@@ -6,6 +6,7 @@ plotting:
   clusters: 48
   planning_horizon: [2030, 2040, 2050]
   time_resolution: "12H"
+  sector_opts: "T-H-B-I"
 
 heat_pumps:
   residential_decentral: 7.5 # (kW_el) https://iea.blob.core.windows.net/assets/4713780d-c0ae-4686-8c9b-29e782452695/TheFutureofHeatPumps.pdf
@@ -15,10 +16,12 @@ heat_pumps:
 set_capacities:
   clusters: 48
   planning_horizon: "2040" # "2040" (2030->2040), "2050" (2040->2050)
-  time_resolution: "100H"
+  time_resolution: "12H"
   scenario: ["flexible", "retro_tes", "flexible-moderate", "rigid"]
+  sector_opts: "T-H-B-I"
 
 moderate_retrofitting:
   clusters: 48
   planning_horizon: "2030"
-  time_resolution: "100H"
+  time_resolution: "12H"
+  sector_opts: "T-H-B-I"

--- a/configs/config.plot.yaml
+++ b/configs/config.plot.yaml
@@ -4,7 +4,7 @@
 
 plotting:
   clusters: 48
-  planning_horizon: [2030, 2040, 2050]
+  planning_horizon: [2020, 2030, 2040, 2050]
   time_resolution: "12H"
   sector_opts: "T-H-B-I"
 

--- a/plots/_helpers.py
+++ b/plots/_helpers.py
@@ -20,41 +20,99 @@ LINE_LIMITS = {"2020": "v1.0",
 # BAU year
 BAU_HORIZON = "2020"
 
-def mock_snakemake(rulename, **wildcards):
+
+def mock_snakemake(
+    rulename,
+    root_dir=None,
+    configfiles=None,
+    submodule_dir="workflow/submodules/pypsa-eur",
+    **wildcards,
+):
     """
     This function is expected to be executed from the 'scripts'-directory of '
     the snakemake project. It returns a snakemake.script.Snakemake object,
     based on the Snakefile.
+
     If a rule has wildcards, you have to specify them in **wildcards.
+
     Parameters
     ----------
     rulename: str
         name of the rule for which the snakemake object should be generated
+    root_dir: str/path-like
+        path to the root directory of the snakemake project
+    configfiles: list, str
+        list of configfiles to be used to update the config
+    submodule_dir: str, Path
+        in case PyPSA-Eur is used as a submodule, submodule_dir is
+        the path of pypsa-eur relative to the project directory.
     **wildcards:
         keyword arguments fixing the wildcards. Only necessary if wildcards are
         needed.
     """
-    import snakemake as sm
     import os
+
+    import snakemake as sm
     from pypsa.descriptors import Dict
+    from snakemake.api import Workflow
+    from snakemake.common import SNAKEFILE_CHOICES
     from snakemake.script import Snakemake
-    from packaging.version import Version, parse
+    from snakemake.settings import (
+        ConfigSettings,
+        DAGSettings,
+        ResourceSettings,
+        StorageSettings,
+        WorkflowSettings,
+    )
 
     script_dir = Path(__file__).parent.resolve()
-    assert (
-        Path.cwd().resolve() == script_dir
-    ), f"mock_snakemake has to be run from the repository scripts directory {script_dir}"
+    if root_dir is None:
+        root_dir = script_dir.parent
+    else:
+        root_dir = Path(root_dir).resolve()
+
+    user_in_script_dir = Path.cwd().resolve() == script_dir
+    if str(submodule_dir) in __file__:
+        # the submodule_dir path is only need to locate the project dir
+        os.chdir(Path(__file__[: __file__.find(str(submodule_dir))]))
+    elif user_in_script_dir:
+        os.chdir(root_dir)
+    elif Path.cwd().resolve() != root_dir:
+        raise RuntimeError(
+            "mock_snakemake has to be run from the repository root"
+            f" {root_dir} or scripts directory {script_dir}"
+        )
     try:
-        os.chdir(script_dir.parent)
-        for p in sm.SNAKEFILE_CHOICES:
+        for p in SNAKEFILE_CHOICES:
             if os.path.exists(p):
                 snakefile = p
                 break
-        kwargs = (
-            dict(rerun_triggers=[]) if parse(sm.__version__) > Version("7.7.0") else {}
+        if configfiles is None:
+            configfiles = []
+        elif isinstance(configfiles, str):
+            configfiles = [configfiles]
+
+        resource_settings = ResourceSettings()
+        config_settings = ConfigSettings(configfiles=map(Path, configfiles))
+        workflow_settings = WorkflowSettings()
+        storage_settings = StorageSettings()
+        dag_settings = DAGSettings(rerun_triggers=[])
+        workflow = Workflow(
+            config_settings,
+            resource_settings,
+            workflow_settings,
+            storage_settings,
+            dag_settings,
+            storage_provider_settings=dict(),
         )
-        workflow = sm.Workflow(snakefile, overwrite_configfiles=[], **kwargs)
         workflow.include(snakefile)
+
+        if configfiles:
+            for f in configfiles:
+                if not os.path.exists(f):
+                    raise FileNotFoundError(f"Config file {f} does not exist.")
+                workflow.configfile(f)
+
         workflow.global_resources = {}
         rule = workflow.get_rule(rulename)
         dag = sm.dag.DAG(workflow, rules=[rule])
@@ -63,7 +121,7 @@ def mock_snakemake(rulename, **wildcards):
 
         def make_accessable(*ios):
             for io in ios:
-                for i in range(len(io)):
+                for i, _ in enumerate(io):
                     io[i] = os.path.abspath(io[i])
 
         make_accessable(job.input, job.output, job.log)
@@ -83,10 +141,10 @@ def mock_snakemake(rulename, **wildcards):
         for path in list(snakemake.log) + list(snakemake.output):
             Path(path).parent.mkdir(parents=True, exist_ok=True)
 
-        return snakemake
-
     finally:
-        os.chdir(script_dir)
+        if user_in_script_dir:
+            os.chdir(script_dir)
+    return snakemake
 
 
 def update_config_from_wildcards(config, w):

--- a/plots/_helpers.py
+++ b/plots/_helpers.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import pypsa
+import logging
 
 # get the base working directory
 BASE_PATH = os.path.abspath(os.path.join(__file__ ,"../.."))
@@ -169,6 +170,7 @@ def load_network(lineex, clusters, sector_opts, planning_horizon, scenario):
     DIR = f"results/{scenario}/postnetworks"
     try:
         n = pypsa.Network(os.path.join(DIR, FILE))
+        logging.info(f"Loading {FILE} in {DIR}")
     except FileNotFoundError as e:
         print(f"Error: {e}")
         return None
@@ -180,6 +182,7 @@ def load_unsolved_network(lineex, clusters, sector_opts, planning_horizon, scena
     DIR = f"results/{scenario}/prenetworks"
     try:
         n = pypsa.Network(os.path.join(DIR, FILE))
+        logging.info(f"Loading {FILE} in {DIR}")
     except FileNotFoundError as e:
         print(f"Error: {e}")
         return None
@@ -190,6 +193,7 @@ def save_unsolved_network(network, lineex, clusters, sector_opts, planning_horiz
     FILE = f"elec_s_{clusters}_l{lineex}__{sector_opts}_{planning_horizon}.nc"
     DIR = f"results/{scenario}/prenetworks/"
     network.export_to_netcdf(DIR+FILE)
+    logging.info(f"Saving {FILE} to {DIR}")
 
 
 def change_path_to_pypsa_eur():

--- a/plots/_helpers.py
+++ b/plots/_helpers.py
@@ -7,6 +7,18 @@ BASE_PATH = os.path.abspath(os.path.join(__file__ ,"../.."))
 # relative path to folder where to store plots
 PATH_PLOTS = "plots/results/"
 
+# Co2L limits
+CO2L_LIMITS = {"2020": "0.7", 
+               "2030": "0.45", 
+               "2040": "0.1", 
+               "2050": "0.0"}
+# Line limits
+LINE_LIMITS = {"2020": "v1.0",
+               "2030": "v1.15",
+               "2040": "v1.3",
+               "2050": "v1.5"}
+# BAU year
+BAU_HORIZON = "2020"
 
 def mock_snakemake(rulename, **wildcards):
     """

--- a/plots/colors.py
+++ b/plots/colors.py
@@ -186,6 +186,7 @@ tech_colors = {
 "urban central resistive heater": '#8cdf85',
 "retrofitting": '#8487e8',
 "building retrofitting": '#8487e8',
+"WWHRS": '#5054de',
 
 "H2 for industry": "#f073da",
 "H2 for shipping": "#ebaee0",

--- a/plots/plot_COP.py
+++ b/plots/plot_COP.py
@@ -1,0 +1,86 @@
+import os
+import sys
+sys.path.append("../submodules/pypsa-eur")
+import matplotlib.pyplot as plt
+import pandas as pd
+import logging
+import yaml
+import warnings
+warnings.filterwarnings("ignore")
+from _helpers import mock_snakemake, update_config_from_wildcards, load_network, \
+                     change_path_to_pypsa_eur, change_path_to_base
+
+
+logger = logging.getLogger(__name__)
+
+RESULTS_DIR = "plots/results"
+DEFAULT_CONFIG_DIR = "config/config.default.yaml"
+TEMP_LOW = -20
+TEMP_HIGH = 40
+
+
+def coefficient_of_performance(delta_T, source="air"):
+    if source == "air":
+        return 6.81 - 0.121 * delta_T + 0.000630 * delta_T**2
+    elif source == "soil":
+        return 8.77 - 0.150 * delta_T + 0.000734 * delta_T**2
+    else:
+        raise NotImplementedError("'source' must be one of  ['air', 'soil']")
+
+
+def get_heat_pump_sink_T():
+    # read heat_pump_sink_T from default config
+    with open(DEFAULT_CONFIG_DIR, 'r') as file:
+        config_default = yaml.safe_load(file)
+
+    heat_pump_sink_T = config_default["sector"]["heat_pump_sink_T"]
+    return heat_pump_sink_T
+
+
+def plot_COP(t, heat_pump_sink_T):
+    # define sources of heat pumps
+    media = {"air": "air heat pumps", 
+             "soil": "ground heat pumps"}
+    
+    # define df for storing COP vs temperatures
+    cop_df = pd.DataFrame(index=t, columns=media.values())
+
+    # delta_T
+    delta_T = heat_pump_sink_T - t
+
+    # compute COP for each sources and temperatures
+    for source, tech_name in media.items():
+        cop = coefficient_of_performance(delta_T, source=source)
+        cop_df.loc[:, tech_name] = cop
+
+    # plot COP
+    fig, ax = plt.subplots(figsize=(7, 3))
+    cop_df.plot(ax=ax)
+    ax.set_ylabel("COP")
+    ax.set_xlabel("Source temperature (°C)")
+    ax.legend(loc="upper left", facecolor="white", fontsize='x-small')
+    plt.savefig(snakemake.output.figure, dpi=600, bbox_inches = 'tight')
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        snakemake = mock_snakemake(
+            "plot_COP", 
+        )
+    # update config based on wildcards
+    config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
+
+    # move to submodules/pypsa-eur
+    change_path_to_pypsa_eur()
+
+    # get_heat_pump_sink_T
+    heat_pump_sink_T = get_heat_pump_sink_T()
+
+    # move to base directory
+    change_path_to_base()
+    
+    # temperature range for plotting COP
+    t = pd.Series(range(TEMP_LOW, TEMP_HIGH))
+
+    # plot COP for air and ground heat pumps
+    plot_COP(t, heat_pump_sink_T)

--- a/plots/plot_co2_level.py
+++ b/plots/plot_co2_level.py
@@ -1,0 +1,141 @@
+import os
+import sys
+sys.path.append("../submodules/pypsa-eur")
+import pypsa
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+import numpy as np
+import pandas as pd
+import geopandas as gpd
+import cartopy.crs as ccrs
+import logging
+import colors as c
+import warnings
+warnings.filterwarnings("ignore")
+from _helpers import mock_snakemake, update_config_from_wildcards, load_network, \
+                     change_path_to_pypsa_eur, change_path_to_base, \
+                     LINE_LIMITS, CO2L_LIMITS, BAU_HORIZON
+
+logger = logging.getLogger(__name__)
+
+RESULTS_DIR = "plots/results"
+
+
+def get_co2(n, nice_name):
+    co2_carrier = 'co2'
+    co2_bus = n.stores.query("carrier in @co2_carrier").index
+    # get co2 level in MtCO2_eq
+    co2_level = n.stores_t.e[co2_bus].iloc[-1]
+    return co2_level.values
+
+
+def plot_co2(df_co2):
+    # color codes for legend
+    color_codes = {"No Renovation and Green Heating":"#f4b609",
+                   "BAU": "grey"}
+    
+    # tCO2_eq to MtCO2_eq
+    df_co2 = df_co2 / 1e6
+    # get BAU year
+    BAU_year = df_co2.filter(like="BAU", axis=1).columns.get_level_values(0)
+
+    fig, ax = plt.subplots(figsize=(7, 3))
+    for nice_name, color_code in color_codes.items():
+        if not nice_name == "BAU":
+            df_co2.loc["Total", (slice(None), nice_name)].plot(ax=ax, color=color_code, 
+                                                                       linewidth=2, marker='o', label="Scenarios", zorder=5)
+        elif nice_name == "BAU" and not BAU_year.empty:
+            ax.axhline(y=df_co2.loc["Total", (BAU_year, nice_name)].values, 
+                       color=color_code, linestyle='--', label=nice_name, zorder=1)
+
+    unique_years = sorted(set(df_co2.columns.get_level_values(0)) - set(BAU_year))
+    ax.set_xticks(range(len(unique_years)))  # Set the tick locations
+    ax.set_xticklabels(unique_years)  # Set the tick labels
+    ax.set_ylabel(r"CO$_2$ emissions [MtCO$_{2-eq}$]")
+    ax.set_xlabel(None)
+    ax.legend(facecolor="white", fontsize='x-small')
+    plt.savefig(snakemake.output.figure, dpi=600, bbox_inches = 'tight')
+    
+
+def define_table_df(scenarios):
+    # Define column levels
+    col_level_0 = ["2030"]*4 + ["2040"]*4 + ["2050"]*4
+    col_level_1 = list(scenarios.values()) * 3
+    # Create a MultiColumns
+    multi_cols = pd.MultiIndex.from_arrays([col_level_0, col_level_1], names=['Year', 'Scenario'])
+    df = pd.DataFrame(columns=multi_cols, index=["Total"])
+    return df
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        snakemake = mock_snakemake(
+            "plot_co2_level", 
+            clusters="48",
+        )
+    # update config based on wildcards
+    config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
+
+    # move to submodules/pypsa-eur
+    change_path_to_pypsa_eur()
+
+    # network parameters
+    co2l_limits = CO2L_LIMITS
+    line_limits = LINE_LIMITS
+    clusters = config["plotting"]["clusters"]
+    opts = config["plotting"]["sector_opts"]
+    planning_horizons = config["plotting"]["planning_horizon"]
+    planning_horizons = [str(x) for x in planning_horizons if not str(x) == BAU_HORIZON]
+    time_resolution = config["plotting"]["time_resolution"]
+
+    # define scenario namings
+    scenarios = {"flexible": "Optimal Renovation and Heating", 
+                "retro_tes": "Optimal Renovation and Green Heating", 
+                "flexible-moderate": "Limited Renovation and Optimal Heating", 
+                "rigid": "No Renovation and Green Heating"}
+
+
+    # initialize df for storing curtailment information
+    co2_df = define_table_df(scenarios)
+
+    for planning_horizon in planning_horizons:
+        lineex = line_limits[planning_horizon]
+        sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
+    
+        # load networks
+        for scenario, nice_name in scenarios.items():
+            n = load_network(lineex, clusters, sector_opts, planning_horizon, scenario)
+
+            if n is None:
+                # Skip further computation for this scenario if network is not loaded
+                print(f"Network is not found for scenario '{scenario}', planning year '{planning_horizon}', and time resolution of '{time_resolution}'. Skipping...")
+                continue
+            
+            co2_level = get_co2(n, nice_name)
+            co2_df.loc["Total", (planning_horizon, nice_name)] = co2_level
+    
+    # Add BAU scenario
+    BAU_horizon = BAU_HORIZON
+    scenario = "BAU"
+    lineex = line_limits[BAU_horizon]
+    sector_opts = f"Co2L{co2l_limits[BAU_horizon]}-{time_resolution}-{opts}"
+
+    n = load_network(lineex, clusters, sector_opts, BAU_horizon, scenario)
+
+    if n is None:
+        # Skip further computation for this scenario if network is not loaded
+        print(f"Network is not found for scenario '{scenario}', planning year '{BAU_horizon}', and time resolution of '{time_resolution}'. Skipping...")
+    else:
+        co2_level = get_co2(n, scenario)
+        co2_df.loc["Total", (BAU_horizon, scenario)] = co2_level
+
+    # move to base directory
+    change_path_to_base()
+
+    # store to csv and png
+    if not co2_df.empty:
+        # save to csv
+        co2_df.to_csv(snakemake.output.table)
+        co2_df.index.name = "CO2 emissions [tCO2_eq]"
+        # make plot
+        plot_co2(co2_df)

--- a/plots/plot_co2_level.py
+++ b/plots/plot_co2_level.py
@@ -224,8 +224,8 @@ def plot_co2_balance(co2_df, clusters, planning_horizon, plot_width=7):
     plt.xticks(rotation=0, fontsize=10)
     ax.set_ylabel("CO$_2$ emissions [tCO$_{2-eq}$]")
     ax.set_xlabel("")
-    ax.set_ylim([-2.8e9,2.8e9])
-    # ax.set_yticks(np.arange(-3e9, 3e9, 5e8))
+    ax.set_ylim([-3e9,3e9])
+    ax.set_yticks(np.arange(-3e9, 3e9, 5e8))
     # Turn off both horizontal and vertical grid lines
     ax.grid(False, which='both')
     ax.legend(

--- a/plots/plot_co2_level.py
+++ b/plots/plot_co2_level.py
@@ -20,45 +20,225 @@ logger = logging.getLogger(__name__)
 
 RESULTS_DIR = "plots/results"
 
+PREFIX_TO_REMOVE = [
+    "residential ",
+    "services ",
+    "urban ",
+    "rural ",
+    "central ",
+    "decentral ",
+]
 
-def get_co2(n, nice_name):
+RENAME_IF_CONTAINS = [
+    "solid biomass CHP",
+    "gas CHP",
+    "gas boiler",
+    "biogas",
+    "solar thermal",
+    "air heat pump",
+    "ground heat pump",
+    "resistive heater",
+    "Fischer-Tropsch",
+]
+
+RENAME_IF_CONTAINS_DICT = {
+    "water tanks": "TES",
+    "retrofitting": "building retrofitting",
+    # "H2 Electrolysis": "hydrogen storage",
+    # "H2 Fuel Cell": "hydrogen storage",
+    # "H2 pipeline": "hydrogen storage",
+    "battery": "battery storage",
+    # "CC": "CC"
+}
+
+RENAME = {
+    "Solar": "solar PV",
+    "solar": "solar PV",
+    "Sabatier": "methanation",
+    "helmeth" : "methanation",
+    "Offshore Wind (AC)": "offshore wind",
+    "Offshore Wind (DC)": "offshore wind",
+    "Onshore Wind": "onshore wind",
+    "offwind-ac": "offshore wind",
+    "offwind-dc": "offshore wind",
+    "Run of River": "hydroelectricity",
+    "Run of river": "hydroelectricity",
+    "Reservoir & Dam": "hydroelectricity",
+    "Pumped Hydro Storage": "hydroelectricity",
+    "PHS": "hydroelectricity",
+    "NH3": "ammonia",
+    "co2 Store": "DAC",
+    "co2 stored": "CO2 sequestration",
+    "AC": "transmission lines",
+    "DC": "transmission lines",
+    "B2B": "transmission lines",
+    "solid biomass for industry": "solid biomass for industry",
+    "solid biomass for industry CC": "solid biomass for industry",
+    "electricity distribution grid": "distribution lines",
+    "Open-Cycle Gas":"OCGT",
+    "gas": "gas storage",
+    'gas pipeline new': 'gas pipeline',
+    "gas for industry CC": "gas for industry",
+    "SMR CC": "SMR",
+    "process emissions CC": "process emissions",
+    "Battery Storage": "battery storage",
+    'H2 Store': "H2 storage",
+    'Hydrogen Storage': "H2 storage",
+    'co2 sequestered': "CO2 sequestration",
+    "solid biomass transport": "solid biomass",
+    "uranium": "nuclear",
+}
+
+
+PREFERRED_ORDER = pd.Index(
+    [
+        "co2",
+        "DAC",
+        "biogas",
+        "solid biomass for industry",
+        "solid biomass CHP",
+
+        "uranium",
+        "nuclear",
+        "solid biomass",
+        "biogas",
+        "solid biomass for industry",
+        "gas for industry",
+        "coal for industry",
+        "methanol",
+        "oil",
+        "lignite",
+        "coal",
+        "shipping oil",
+        "shipping methanol",
+        "naphtha for industry",
+        "land transport oil",
+        "kerosene for aviation",
+        
+        "transmission lines",
+        "distribution lines",
+        "gas pipeline",
+        "H2 pipeline",
+        
+        "H2 Electrolysis",
+        "H2 Fuel Cell",
+        "DAC",
+        "Fischer-Tropsch",
+        "methanation",
+        "BEV charger",
+        "V2G",
+        "SMR",
+        "methanolisation",
+        
+        "battery storage",
+        "gas storage",
+        "H2 storage",
+        "TES",
+        
+        "hydroelectricity",
+        "OCGT",
+        "onshore wind",
+        "offshore wind",
+        "solar PV",
+        "solar thermal",
+        "solar rooftop",
+
+        "co2",
+        "CO2 sequestration",
+        "process emissions",
+
+        "gas CHP",
+        "resistive heater",
+        "air heat pump",
+        "ground heat pump",
+        "gas boiler",
+        "biomass boiler",
+        "WWHRS",
+        "building retrofitting",
+        "WWHRS",
+     ]
+)
+
+
+def rename_techs(label):
+
+    for ptr in PREFIX_TO_REMOVE:
+        if label[: len(ptr)] == ptr:
+            label = label[len(ptr) :]
+
+    for rif in RENAME_IF_CONTAINS:
+        if rif in label:
+            label = rif
+
+    for old, new in RENAME_IF_CONTAINS_DICT.items():
+        if old in label:
+            label = new
+
+    for old, new in RENAME.items():
+        if old == label:
+            label = new
+    return label
+
+def get_co2_balance(n, nice_name):
     co2_carrier = 'co2'
-    co2_bus = n.stores.query("carrier in @co2_carrier").index
-    # get co2 level in MtCO2_eq
-    co2_level = n.stores_t.e[co2_bus].iloc[-1]
-    return co2_level.values
+    balance = n.statistics.energy_balance()
+    # get co2 balance
+    df = balance.loc[:, :, co2_carrier].droplevel(0).groupby(level=0).sum().to_frame()
+    df.columns = [nice_name]
+    return df
 
 
-def plot_co2(df_co2):
-    # color codes for legend
-    color_codes = {"Optimal Renovation and Heating":"purple", 
-                   "Optimal Renovation and Green Heating":"limegreen", 
-                   "Limited Renovation and Optimal Heating":"royalblue", 
-                   "No Renovation and Green Heating":"#f4b609",
-                   "BAU": "grey"}
-    
-    # tCO2_eq to MtCO2_eq
-    df_co2 = df_co2 / 1e6
-    # get BAU year
-    BAU_year = df_co2.filter(like="BAU", axis=1).columns.get_level_values(0)
+def plot_co2_balance(co2_df, clusters, planning_horizon, plot_width=7):
+    # filter out technologies with very small emission
+    co2_threshold = 20e6 # 1% of 2e9
+    to_drop = co2_df.index[co2_df.abs().max(axis=1) < co2_threshold]
+    logger.info(
+        f"Dropping technology with co2 balance below {co2_threshold} ton CO2_eq per year"
+    )
+    logger.debug(co2_df.loc[to_drop])
+    co2_df = co2_df.drop(to_drop)
 
-    fig, ax = plt.subplots(figsize=(7, 3))
-    for nice_name, color_code in color_codes.items():
-        if not nice_name == "BAU":
-            df_co2.loc["Total", (slice(None), nice_name)].plot(ax=ax, color=color_code, 
-                                                                       linewidth=2, marker='o', label=nice_name, zorder=5)
-        elif nice_name == "BAU" and not BAU_year.empty:
-            ax.axhline(y=df_co2.loc["Total", (BAU_year, nice_name)].values, 
-                       color=color_code, linestyle='--', label=nice_name, zorder=1)
+    # reorder index
+    new_index = PREFERRED_ORDER.intersection(co2_df.index).append(
+        co2_df.index.difference(PREFERRED_ORDER)
+    )
+    co2_reordered = co2_df.T[new_index]
 
-    unique_years = sorted(set(df_co2.columns.get_level_values(0)) - set(BAU_year))
-    ax.set_xticks(range(len(unique_years)))  # Set the tick locations
-    ax.set_xticklabels(unique_years)  # Set the tick labels
-    ax.set_ylabel(r"CO$_2$ emissions [MtCO$_{2-eq}$]")
-    ax.set_xlabel(None)
-    ax.legend(facecolor="white", fontsize='x-small', loc="upper right")
-    plt.savefig(snakemake.output.figure, dpi=600, bbox_inches = 'tight')
-    
+    # get colors
+    colors = c.tech_colors
+    # plot co2 balance
+    fig, ax = plt.subplots(figsize=(plot_width,9))
+    co2_reordered.plot.bar(ax=ax, 
+                           stacked=True, 
+                           color=[colors[x] for x in co2_reordered.columns])
+    # configure plot
+    handles, labels = ax.get_legend_handles_labels()
+    handles.reverse()
+    labels.reverse()
+    # reverse negatives co2 technologies
+    negative_co2_names = co2_reordered.loc[:, co2_reordered.mean()<0].columns
+    neg_co2_length = len(negative_co2_names)
+    handles = handles[:-neg_co2_length] + handles[-neg_co2_length:][::-1]
+    labels = labels[:-neg_co2_length] + labels[-neg_co2_length:][::-1]
+
+    plt.xticks(rotation=0, fontsize=10)
+    ax.set_ylabel("CO$_2$ emissions [tCO$_{2-eq}$]")
+    ax.set_xlabel("")
+    ax.set_ylim([-2.8e9,2.8e9])
+    # ax.set_yticks(np.arange(-3e9, 3e9, 5e8))
+    # Turn off both horizontal and vertical grid lines
+    ax.grid(False, which='both')
+    ax.legend(
+        handles, labels, ncol=1, loc="upper left", bbox_to_anchor=[1, 1], frameon=False
+    )
+    ax.set_facecolor('white')
+    ax.spines['top'].set_visible(False)
+    ax.spines['right'].set_visible(False)
+    ax.spines['left'].set_color('black')
+    ax.spines['bottom'].set_color('black')
+    ax.grid(axis='y', linestyle='--', linewidth=0.5, color='gray', zorder=0)
+    plt.savefig(f"{RESULTS_DIR}/plot_co2_level_{clusters}_{planning_horizon}.png", dpi=600, bbox_inches='tight')
+
 
 def define_table_df(scenarios):
     # Define column levels
@@ -66,7 +246,15 @@ def define_table_df(scenarios):
     col_level_1 = list(scenarios.values()) * 3
     # Create a MultiColumns
     multi_cols = pd.MultiIndex.from_arrays([col_level_0, col_level_1], names=['Year', 'Scenario'])
-    df = pd.DataFrame(columns=multi_cols, index=["Total"])
+    df = pd.DataFrame(columns=multi_cols)
+    return df
+
+
+def fill_table_df(df, planning_horizon, scenarios, values):
+    for scenario in scenarios.values():
+        for tech_name, _ in values.iterrows():
+            if scenario in values.columns:
+                df.loc[tech_name, (planning_horizon, scenario)] = values.loc[tech_name, scenario]
     return df
 
 
@@ -79,8 +267,6 @@ if __name__ == "__main__":
     # update config based on wildcards
     config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
 
-    # move to submodules/pypsa-eur
-    change_path_to_pypsa_eur()
 
     # network parameters
     co2l_limits = CO2L_LIMITS
@@ -92,20 +278,24 @@ if __name__ == "__main__":
     time_resolution = config["plotting"]["time_resolution"]
 
     # define scenario namings
-    scenarios = {"flexible": "Optimal Renovation and Heating", 
-                "retro_tes": "Optimal Renovation and Green Heating", 
-                "flexible-moderate": "Limited Renovation and Optimal Heating", 
-                "rigid": "No Renovation and Green Heating"}
+    scenarios = {"flexible": "Optimal \nRenovation &\nHeating", 
+                "retro_tes": "Optimal \nRenovation &\nGreen Heating", 
+                "flexible-moderate": "Limited \nRenovation &\nOptimal Heating", 
+                "rigid": "No \nRenovation &\nGreen Heating"}
 
 
-    # initialize df for storing curtailment information
-    co2_df = define_table_df(scenarios)
+    # initialize df for storing co2 balance information
+    table_co2_df = define_table_df(scenarios)
 
     for planning_horizon in planning_horizons:
         lineex = line_limits[planning_horizon]
         sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
+
+        # move to submodules/pypsa-eur
+        change_path_to_pypsa_eur()
     
         # load networks
+        co2_df = pd.DataFrame()
         for scenario, nice_name in scenarios.items():
             n = load_network(lineex, clusters, sector_opts, planning_horizon, scenario)
 
@@ -114,8 +304,18 @@ if __name__ == "__main__":
                 print(f"Network is not found for scenario '{scenario}', planning year '{planning_horizon}', and time resolution of '{time_resolution}'. Skipping...")
                 continue
             
-            co2_level = get_co2(n, nice_name)
-            co2_df.loc["Total", (planning_horizon, nice_name)] = co2_level
+            co2_balance = get_co2_balance(n, nice_name)
+            co2_df = co2_df.join(co2_balance, how="outer").fillna(0)
+        # grouping and renaming technologies
+        co2_df = co2_df.groupby(co2_df.index.map(rename_techs)).sum()
+
+        # move to base directory
+        change_path_to_base()
+
+        # plot co2 balance
+        if not co2_df.empty:
+            plot_co2_balance(co2_df, clusters, planning_horizon)
+            table_co2_df = fill_table_df(table_co2_df, planning_horizon, scenarios, co2_df)
     
     # Add BAU scenario
     BAU_horizon = BAU_HORIZON
@@ -123,22 +323,32 @@ if __name__ == "__main__":
     lineex = line_limits[BAU_horizon]
     sector_opts = f"Co2L{co2l_limits[BAU_horizon]}-{time_resolution}-{opts}"
 
+    # move to submodules/pypsa-eur
+    change_path_to_pypsa_eur()
+
     n = load_network(lineex, clusters, sector_opts, BAU_horizon, scenario)
+
+    # move to base directory
+    change_path_to_base()
 
     if n is None:
         # Skip further computation for this scenario if network is not loaded
         print(f"Network is not found for scenario '{scenario}', planning year '{BAU_horizon}', and time resolution of '{time_resolution}'. Skipping...")
     else:
-        co2_level = get_co2(n, scenario)
-        co2_df.loc["Total", (BAU_horizon, scenario)] = co2_level
+        # get co2 balance for BAU and group technologies
+        co2_BAU = get_co2_balance(n, "BAU")
+        co2_BAU = co2_BAU.groupby(co2_BAU.index.map(rename_techs)).sum()
+        if not table_co2_df.empty and not co2_BAU.empty:
+            plot_co2_balance(co2_BAU, clusters, BAU_horizon, plot_width=1.5)
+            table_co2_df = fill_table_df(table_co2_df, BAU_horizon, {"BAU":"BAU"}, co2_BAU)
+            table_co2_df = table_co2_df.fillna(0)
+
 
     # move to base directory
     change_path_to_base()
 
-    # store to csv and png
-    if not co2_df.empty:
+    # store to csv
+    if not table_co2_df.empty:
         # save to csv
-        co2_df.to_csv(snakemake.output.table)
-        co2_df.index.name = "CO2 emissions [tCO2_eq]"
-        # make plot
-        plot_co2(co2_df)
+        table_co2_df.index.name = "CO2 emissions [tCO2_eq]"
+        table_co2_df.to_csv(snakemake.output.table)

--- a/plots/plot_co2_level.py
+++ b/plots/plot_co2_level.py
@@ -31,7 +31,10 @@ def get_co2(n, nice_name):
 
 def plot_co2(df_co2):
     # color codes for legend
-    color_codes = {"No Renovation and Green Heating":"#f4b609",
+    color_codes = {"Optimal Renovation and Heating":"purple", 
+                   "Optimal Renovation and Green Heating":"limegreen", 
+                   "Limited Renovation and Optimal Heating":"royalblue", 
+                   "No Renovation and Green Heating":"#f4b609",
                    "BAU": "grey"}
     
     # tCO2_eq to MtCO2_eq
@@ -43,7 +46,7 @@ def plot_co2(df_co2):
     for nice_name, color_code in color_codes.items():
         if not nice_name == "BAU":
             df_co2.loc["Total", (slice(None), nice_name)].plot(ax=ax, color=color_code, 
-                                                                       linewidth=2, marker='o', label="Scenarios", zorder=5)
+                                                                       linewidth=2, marker='o', label=nice_name, zorder=5)
         elif nice_name == "BAU" and not BAU_year.empty:
             ax.axhline(y=df_co2.loc["Total", (BAU_year, nice_name)].values, 
                        color=color_code, linestyle='--', label=nice_name, zorder=1)
@@ -53,7 +56,7 @@ def plot_co2(df_co2):
     ax.set_xticklabels(unique_years)  # Set the tick labels
     ax.set_ylabel(r"CO$_2$ emissions [MtCO$_{2-eq}$]")
     ax.set_xlabel(None)
-    ax.legend(facecolor="white", fontsize='x-small')
+    ax.legend(facecolor="white", fontsize='x-small', loc="upper right")
     plt.savefig(snakemake.output.figure, dpi=600, bbox_inches = 'tight')
     
 

--- a/plots/plot_curtailment.py
+++ b/plots/plot_curtailment.py
@@ -68,7 +68,7 @@ def plot_curtailment(df_curtailment):
     ax.set_ylabel("Curtailment [TWh]")
     ax.set_xlabel(None)
     ax.legend(loc="upper right", facecolor="white", fontsize='x-small')
-    plt.savefig(f"{RESULTS_DIR}/plot_curtailment_{clusters}.png", dpi=600, bbox_inches = 'tight')
+    plt.savefig(snakemake.output.figure, dpi=600, bbox_inches = 'tight')
     
 
 def define_table_df(scenarios):

--- a/plots/plot_curtailment.py
+++ b/plots/plot_curtailment.py
@@ -106,7 +106,8 @@ if __name__ == "__main__":
     line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     opts = config["plotting"]["sector_opts"]
-    planning_horizons = ["2030", "2040", "2050"]
+    planning_horizons = config["plotting"]["planning_horizon"]
+    planning_horizons = [str(x) for x in planning_horizons if not str(x) == BAU_HORIZON]
     time_resolution = config["plotting"]["time_resolution"]
 
     # define scenario namings

--- a/plots/plot_electricity_for_heat.py
+++ b/plots/plot_electricity_for_heat.py
@@ -68,11 +68,11 @@ def plot_elec_consumption_for_heat(dict_elec):
         ax = axes[i]
         ax.set_facecolor("whitesmoke")
 
-        print("Hard coded coordinates on x-axis, selected for 12H granularity")
-        where = [2*7, 2*7*10]
+        print("Hard coded coordinates on x-axis, selected for 3H granularity")
+        where = [56, 224]
 
-        elec_demand_f_heating = elec_demand_f_heating.reset_index()[["ground heat pump", "air heat pump", "gas boiler", "resistive heater"]]
-        colors = ["#2fb537", "#48f74f", "#db6a25", "#d8f9b8", "#e69487", "#8d5e56", "#ffbf2b"]
+        elec_demand_f_heating = elec_demand_f_heating.reset_index()[["ground heat pump", "air heat pump", "resistive heater", "gas boiler"]]
+        colors = ["#2fb537", "#48f74f", "#d8f9b8", "#db6a25"]
 
         (elec_demand_f_heating/1e3).iloc[where[0] : where[1]].plot(
             kind='area', stacked=True, color=colors, legend=False,
@@ -80,7 +80,7 @@ def plot_elec_consumption_for_heat(dict_elec):
         )
 
         ax.set_xlabel("", fontsize=12)
-        ax.set_ylim([0,600])
+        ax.set_ylim([0,900])
 
         if i <3:
             ax.set_xticks([])
@@ -104,8 +104,8 @@ def plot_elec_consumption_for_heat(dict_elec):
     ax1.legend(
         reversed(handles1[0:7]),
         [
-            "Resistive Heaters (electricity)",
             "Gas Boilers (gas)",
+            "Resistive Heaters (electricity)",
             "Air-Sourced Heat Pumps (electricity)",
             "Ground-Sourced Heat Pumps (electricity)"
         ],

--- a/plots/plot_electricity_generation.py
+++ b/plots/plot_electricity_generation.py
@@ -7,7 +7,20 @@ import pandas as pd
 import warnings
 warnings.filterwarnings("ignore")
 from _helpers import mock_snakemake, update_config_from_wildcards, load_network, \
-                     change_path_to_pypsa_eur, change_path_to_base
+                     change_path_to_pypsa_eur, change_path_to_base, \
+                     LINE_LIMITS, CO2L_LIMITS, BAU_HORIZON
+
+
+def autopct_format_inner(value, threshold=1):
+    return f'{value:.1f}%' if value >= threshold else ''
+
+
+def autopct_format_outer(value, threshold=3):
+    return f'{value:.1f}%' if value >= threshold else ''
+
+
+def filter_labels(labels, autopct_values):
+    return [label if autopct_values[i] else None for i, label in enumerate(labels)]
 
 
 def plot_pies(ax, elec_mix_array):
@@ -15,16 +28,25 @@ def plot_pies(ax, elec_mix_array):
     vals = np.array(elec_mix_array)
 
     cmap = plt.colormaps["tab20c"]
-    outer_colors = ["#ff8c00", "#0fa101", "#db6a25"]
+    outer_colors = ["#ff8c00", "#db6a25", "#0fa101", "#545454"]
     inner_colors = cmap([1, 2, 5, 6, 9, 10])
-    inner_colors = ["#ff8c00", "#6895dd", "#235ebc", "#3dbfb0", "#f9d002", '#ffea80', "#db6a25"]
+    inner_colors = ["#ff8c00", "#db6a25", "#6895dd", "#235ebc", "#3dbfb0", "#f9d002", '#ffea80', "#545454", "#826837"]
 
-    outer_labels = ["Nuclear", "VRES", "Gas"]
+    outer_labels = ["Nuclear", "Gas", "VRES", "Coal"]
 
-    wedges, texts, autotexts = ax.pie(vals.sum(axis=1), radius=1, colors=outer_colors,
+    # threshold to show outer label
+    threshold = 2.0
+    # get percentage of outer layer  
+    autopct_values = [100*value/vals.sum(axis=1).sum() for value in vals.sum(axis=1)]
+    # filter out percentages lower than threshold
+    autopct_values = [value if value >= threshold else None for value in autopct_values]
+    # outer labels that has value >= threshold 
+    valid_outer_labels = filter_labels(outer_labels, autopct_values)
+
+    _, texts, autotexts = ax.pie(vals.sum(axis=1), radius=1, colors=outer_colors,
         wedgeprops=dict(width=size, edgecolor='w', linewidth=0.2), 
-        autopct='%.1f%%', textprops={'fontsize': 4}, pctdistance=1.5,
-        labels=outer_labels)
+        autopct=autopct_format_outer, textprops={'fontsize': 4}, pctdistance=1.5,
+        labels=valid_outer_labels)
     
     # Adjust the position of autopct labels
     for autotext, label in zip(autotexts, texts):
@@ -37,7 +59,7 @@ def plot_pies(ax, elec_mix_array):
     all_vals = vals.flatten()
     ax.pie(all_vals[all_vals!=0], radius=1.15-size, colors=inner_colors,
        wedgeprops=dict(width=size, edgecolor='w', linewidth=0.2),
-       autopct='%.1f%%', textprops={'fontsize': 3}, pctdistance=0.7)
+       autopct=autopct_format_inner, textprops={'fontsize': 3}, pctdistance=0.7)
 
     ax.set(aspect="equal")
 
@@ -45,7 +67,7 @@ def plot_pies(ax, elec_mix_array):
 if __name__ == "__main__":
     if "snakemake" not in globals():
         snakemake = mock_snakemake(
-            "plot_electricity_generation_pies", 
+            "plot_electricity_generation", 
             clusters="48",
             planning_horizon="2030",
         )
@@ -53,34 +75,43 @@ if __name__ == "__main__":
     config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
 
     # network parameters
-    co2l_limits = {"2030":"0.45", "2040":"0.1", "2050":"0.0"}
-    line_limits = {"2030":"v1.15", "2040":"v1.3", "2050":"v1.5"}
+    co2l_limits = CO2L_LIMITS
+    line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     planning_horizon = config["plotting"]["planning_horizon"]
     time_resolution = config["plotting"]["time_resolution"]
+    opts = config["plotting"]["sector_opts"]
     lineex = line_limits[planning_horizon]
-    sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-T-H-B-I"
+    sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
 
     # move to submodules/pypsa-eur
     change_path_to_pypsa_eur()
 
     # define scenario namings
-    scenarios = {"flexible": "OROH", 
-                 "retro_tes": "ORGH", 
-                 "flexible-moderate": "LROH", 
-                 "rigid": "NROH"}
+    if planning_horizon == BAU_HORIZON:
+        scenarios = {"BAU": "BAU"}
+    else:
+        scenarios = {"flexible": "OROH", 
+                     "retro_tes": "ORGH", 
+                     "flexible-moderate": "LROH", 
+                     "rigid": "NROH"}
 
     # define figure
-    fig, (ax1, ax2, ax3, ax4) = plt.subplots(1, 4) #each scenario one axis
-    axes = [ax1, ax2, ax3, ax4]
+    count_scenarios = len(scenarios.keys())
+    fig, axes = plt.subplots(1, count_scenarios, figsize=(1.6*count_scenarios, 1.9)) #each scenario one axis
 
     # load networks
     i = 0
     for scenario, nice_name in scenarios.items():
-        ax = axes[i]
+        ax = axes[i] if isinstance(axes, np.ndarray) else axes
         i += 1
-        
+
         n = load_network(lineex, clusters, sector_opts, planning_horizon, scenario)
+
+        if n is None:
+            # Skip further computation for this scenario if network is not loaded
+            print(f"Network is not found for scenario '{scenario}', planning year '{planning_horizon}', and time resolution of '{time_resolution}'. Skipping...")
+            continue
 
         # definde elec buses
         elec = ["AC", "low voltage"]
@@ -97,9 +128,18 @@ if __name__ == "__main__":
         buses = n.stores.query("carrier == 'gas'").bus
         links = n.links.query("bus0 in @buses and bus1 in @elec").index
         elec_mix_gas = -1*n.links_t.p1[links].multiply(n.snapshot_weightings.objective,axis=0).T.groupby(n.links.carrier).sum().T.sum()
+        # elec mix links (nuclear)
+        buses = n.stores.query("carrier == 'uranium'").bus
+        links = n.links.query("bus0 in @buses and bus1 in @elec").index
+        elec_mix_nuc = -1*n.links_t.p1[links].multiply(n.snapshot_weightings.objective,axis=0).T.groupby(n.links.carrier).sum().T.sum()
+        # elec mix links (coal/lignite)
+        buses = n.stores.query("carrier in ['coal', 'lignite']").bus
+        links = n.links.query("bus0 in @buses and bus1 in @elec").index
+        elec_mix_coal = -1*n.links_t.p1[links].multiply(n.snapshot_weightings.objective,axis=0).T.groupby(n.links.carrier).sum().T.sum()
 
         elec_mix_array = [
-            [elec_mix.loc[["nuclear"]].sum(), 0, 0 , 0, 0],
+            [elec_mix_nuc.sum(), 0, 0, 0, 0],
+            [elec_mix_gas.sum(), 0, 0, 0, 0],
             [
                 elec_mix.loc[["offwind-ac", "offwind-dc"]].sum(),
                 elec_mix.loc[["onwind"]].sum(),
@@ -107,7 +147,7 @@ if __name__ == "__main__":
                 elec_mix.loc[["solar"]].sum(), 
                 elec_mix.loc[["solar rooftop"]].sum(),
             ],
-            [elec_mix_gas.sum(), 0, 0, 0, 0]
+            [elec_mix_coal.loc["coal"].sum(), elec_mix_coal.loc["lignite"].sum(), 0, 0, 0]
         ]
 
         plot_pies(ax, elec_mix_array)
@@ -119,16 +159,24 @@ if __name__ == "__main__":
     nuclear_patch = mpatches.Patch(color='#ff8c00', label='Nuclear')
     onwind_patch = mpatches.Patch(color='#235ebc', label='Onshore Wind')
     offwind_patch = mpatches.Patch(color='#6895dd', label='Offshore Wind')
-    ror_patch = mpatches.Patch(color='#3dbfb0', label='Run of River')
+    ror_patch = mpatches.Patch(color='#3dbfb0', label='Hydropower')
     solar_patch = mpatches.Patch(color='#f9d002', label='Solar utility')
     solar_rooftop_patch = mpatches.Patch(color='#ffea80', label='Solar rooftop')
     gas_patch = mpatches.Patch(color='#db6a25', label='Gas')
     vres_patch = mpatches.Patch(color='#0fa101', label='VRES')
+    coal_patch = mpatches.Patch(color='#545454', label='Hard Coal')
+    lignite_patch = mpatches.Patch(color='#826837', label='Lignite')
 
-    axes[1].legend(
-    handles=[nuclear_patch, vres_patch, gas_patch, onwind_patch, offwind_patch, ror_patch, solar_patch, solar_rooftop_patch],
-    loc="lower center", ncol=4, fontsize=4, bbox_to_anchor=(1.1, -0.15)
-    )
+    if isinstance(axes, np.ndarray):
+        axes[1].legend(
+        handles=[nuclear_patch, vres_patch, gas_patch, coal_patch, lignite_patch, onwind_patch, offwind_patch, ror_patch, solar_patch, solar_rooftop_patch],
+        loc="lower center", ncol=5, fontsize=4, bbox_to_anchor=(1.1, -0.15)
+        )
+    else:
+        axes.legend(
+        handles=[nuclear_patch, vres_patch, gas_patch, coal_patch, lignite_patch, onwind_patch, offwind_patch, ror_patch, solar_patch, solar_rooftop_patch],
+        loc="lower center", ncol=5, fontsize=4, bbox_to_anchor=(0.5, -0.15)
+        )
     
     # move to base directory
     change_path_to_base()

--- a/plots/plot_electricity_generation.py
+++ b/plots/plot_electricity_generation.py
@@ -60,7 +60,11 @@ def plot_pies(ax, elec_mix_array):
     ax.pie(all_vals[all_vals!=0], radius=1.15-size, colors=inner_colors,
        wedgeprops=dict(width=size, edgecolor='w', linewidth=0.2),
        autopct=autopct_format_inner, textprops={'fontsize': 3}, pctdistance=0.7)
-
+    
+    # Calculate total generated electricity
+    total_electricity = np.sum(vals)
+    # Add total generated electricity to the center of the pie chart
+    ax.text(0, 0, f"{total_electricity/1e6:.2f}"+"\nTWh", ha='center', va='center', fontsize=4)
     ax.set(aspect="equal")
 
 

--- a/plots/plot_heat_tech_ratio.py
+++ b/plots/plot_heat_tech_ratio.py
@@ -106,7 +106,8 @@ if __name__ == "__main__":
     line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     time_resolution = config["plotting"]["time_resolution"]
-    planning_horizons = ["2030", "2040", "2050", "2020"]
+    planning_horizons = config["plotting"]["planning_horizon"]
+    planning_horizons = [str(x) for x in planning_horizons]
     opts = config["plotting"]["sector_opts"]
 
     # define scenario namings
@@ -125,6 +126,11 @@ if __name__ == "__main__":
         # if planning_horizon is 2020
         if planning_horizon == BAU_HORIZON:
             scenarios = {"BAU": "BAU"}
+        else:
+            scenarios = {"flexible": "Optimal \nRenovation &\nHeating", 
+                         "retro_tes": "Optimal \nRenovation &\nGreen Heating", 
+                         "flexible-moderate": "Limited \nRenovation &\nOptimal Heating", 
+                         "rigid": "No \nRenovation &\nGreen Heating"}
 
         # move to submodules/pypsa-eur
         change_path_to_pypsa_eur()

--- a/plots/plot_heat_tech_ratio.py
+++ b/plots/plot_heat_tech_ratio.py
@@ -1,0 +1,163 @@
+import sys
+sys.path.append("../submodules/pypsa-eur")
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings("ignore")
+import colors as c
+from _helpers import mock_snakemake, update_config_from_wildcards, load_network, \
+                     change_path_to_pypsa_eur, change_path_to_base, \
+                     LINE_LIMITS, CO2L_LIMITS, BAU_HORIZON, PATH_PLOTS
+
+
+def get_heat_capacities(n, nice_name):
+    # geat heat pump capacity [MW_el]
+    heat_pump_carriers = [x for x in n.links.carrier.unique() if "heat pump" in x]
+    heat_pump_cap = n.links.query("carrier in @heat_pump_carriers").p_nom_opt.sum()
+    # get resistive heater capacity [MW_el]
+    resistive_heater_carriers = [x for x in n.links.carrier.unique() if "resistive heater" in x]
+    resistive_heater_cap = n.links.query("carrier in @resistive_heater_carriers").p_nom_opt.sum()
+    # get gas boiler capacity [MW_el]
+    gas_boiler_carriers = [x for x in n.links.carrier.unique() if "gas boiler" in x]
+    gas_boiler_cap = n.links.query("carrier in @gas_boiler_carriers").p_nom_opt.sum()
+
+    heat_tech_dict = {"heat pump": heat_pump_cap,
+                      "resistive heater": resistive_heater_cap,
+                      "gas boiler": gas_boiler_cap}
+    heat_tech_caps = pd.Series(heat_tech_dict)
+    heat_tech_caps.name = nice_name
+
+    return heat_tech_caps
+
+
+def plot_capacities(capacities_df, clusters, planning_horizon, plot_width=7):
+    # MW to GW
+    df = capacities_df / 1e3
+
+    # narrow plot if BAU
+    if planning_horizon == BAU_HORIZON:
+        plot_width = 1.5
+
+    fig, ax = plt.subplots(figsize=(plot_width, 9))
+
+    df.T.plot(
+        kind="bar",
+        ax=ax,
+        stacked=True,
+        color=[c.tech_colors[i] for i in df.index],
+        zorder=1,
+    )
+
+    handles, labels = ax.get_legend_handles_labels()
+    handles.reverse()
+    labels.reverse()
+
+    plt.xticks(rotation=0, fontsize=10)
+    ax.set_ylabel("Capacity [$\mathrm{GW_{el}}$]")
+    ax.set_xlabel("")
+    ax.set_ylim([0, 1300])
+    # Turn off both horizontal and vertical grid lines
+    ax.grid(False, which='both')
+    ax.legend(
+        handles, labels, ncol=1, loc="upper left", bbox_to_anchor=[1, 1], frameon=False
+    )
+    ax.set_facecolor('white')
+    ax.spines['top'].set_visible(False)
+    ax.spines['right'].set_visible(False)
+    ax.spines['left'].set_color('black')
+    ax.spines['bottom'].set_color('black')
+    ax.grid(axis='y', linestyle='--', linewidth=0.5, color='gray', zorder=0)
+    plt.savefig(f"{PATH_PLOTS}/plot_heat_tech_ratio_{clusters}_{planning_horizon}.png", dpi=600, bbox_inches = 'tight')
+
+
+def define_table_df(scenarios):
+    # Define column levels
+    col_level_0 = ["2030"]*4 + ["2040"]*4 + ["2050"]*4
+    col_level_1 = list(scenarios.values()) * 3
+    # Create a MultiColumns
+    multi_cols = pd.MultiIndex.from_arrays([col_level_0, col_level_1], names=['Year', 'Scenario'])
+    df = pd.DataFrame(columns=multi_cols)
+    return df
+
+
+def fill_table_df(df, planning_horizon, scenarios, values):
+    for scenario in scenarios.values():
+        for tech_name, _ in values.iterrows():
+            if scenario in values.columns:
+                df.loc[tech_name, (planning_horizon, scenario)] = values.loc[tech_name, scenario]
+    return df
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        snakemake = mock_snakemake(
+            "plot_heat_tech_ratio", 
+            clusters="48",
+            planning_horizon="2030",
+        )
+    # update config based on wildcards
+    config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
+
+
+    # network parameters
+    co2l_limits = CO2L_LIMITS
+    line_limits = LINE_LIMITS
+    clusters = config["plotting"]["clusters"]
+    time_resolution = config["plotting"]["time_resolution"]
+    planning_horizons = ["2030", "2040", "2050", "2020"]
+    opts = config["plotting"]["sector_opts"]
+
+    # define scenario namings
+    scenarios = {"flexible": "Optimal \nRenovation &\nHeating", 
+                 "retro_tes": "Optimal \nRenovation &\nGreen Heating", 
+                 "flexible-moderate": "Limited \nRenovation &\nOptimal Heating", 
+                 "rigid": "No \nRenovation &\nGreen Heating"}
+
+    # initialize df for storing table information
+    table_cap_df = define_table_df(scenarios)
+    
+    for planning_horizon in planning_horizons:
+        lineex = line_limits[planning_horizon]
+        sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
+
+        # if planning_horizon is 2020
+        if planning_horizon == BAU_HORIZON:
+            scenarios = {"BAU": "BAU"}
+
+        # move to submodules/pypsa-eur
+        change_path_to_pypsa_eur()
+        
+        # define dataframe to store heat tech capacities
+        capacities_df = pd.DataFrame()
+
+        # compute heat tech capacities
+        for scenario, nice_name in scenarios.items():
+            # load the network
+            n = load_network(lineex, clusters, sector_opts, planning_horizon, scenario)
+
+            if n is None:
+                # Skip further computation for this scenario if network is not loaded
+                print(f"Network is not found for scenario '{scenario}', planning year '{planning_horizon}', and time resolution of '{time_resolution}'. Skipping...")
+                continue
+
+            # get heat tech capacities
+            heat_tech_caps = get_heat_capacities(n, nice_name)
+            capacities_df = pd.concat([capacities_df, heat_tech_caps], axis=1)
+
+        # move to base directory
+        change_path_to_base()
+
+        # plot capacities
+        if not capacities_df.empty:
+            # plot figures
+            plot_capacities(capacities_df, clusters, planning_horizon)
+            # store to df
+            table_cap_df = fill_table_df(table_cap_df, planning_horizon, scenarios, capacities_df)
+            
+    if not table_cap_df.empty:
+        # save to csv
+        table_cap_df.index.name = "Capacity [MW_el]"
+        table_cap_df.to_csv(snakemake.output.table)
+        

--- a/plots/plot_hydrogen_production.py
+++ b/plots/plot_hydrogen_production.py
@@ -21,26 +21,20 @@ logger = logging.getLogger(__name__)
 RESULTS_DIR = "plots/results"
 
 
-def get_curtailment(n, nice_name):
-    curtailments = n.statistics()[["Curtailment"]]
-    techs = {
-             "Solar Rooftop PV": ["solar rooftop"],
-             "Solar Utility PV": ["Solar"],
-             "Onshore Wind": ["Onshore Wind"],
-             "Offshore Wind": ["Offshore Wind (AC)", "Offshore Wind (DC)"]
-             }
-    
-    curtailment_dict = {}
+def get_hydrogen_production(n, param_dict):
+    tech = 'H2 Electrolysis'
+    hydrogen_links = n.links.query("carrier in @tech").index
 
-    for name, tech in techs.items():
-        curtailment_dict[name] = curtailments[curtailments.index.get_level_values(1).isin(tech)].sum().item()
+    hydrogen_dict = {}
 
-    curtailment_dict["Total"] = sum(curtailment_dict.values())
+    for name, param in param_dict.items():
+        sign = -1 if param == "p1" else 1
+        hydrogen_dict[name] = n.links_t[param][hydrogen_links].multiply(n.snapshot_weightings.stores, axis=0).sum().sum() * sign / 1e6
 
-    return curtailment_dict
+    return hydrogen_dict
 
 
-def plot_curtailment(df_curtailment):
+def plot_hydrogen_production(df_hydrogen, figure_dict):
     # color codes for legend
     color_codes = {"Optimal Renovation and Heating":"purple", 
                    "Optimal Renovation and Green Heating":"limegreen", 
@@ -48,37 +42,35 @@ def plot_curtailment(df_curtailment):
                    "No Renovation and Green Heating":"#f4b609",
                    "BAU": "grey"}
     
-    # MWh to TWh
-    df_curtailment = df_curtailment / 1e6
     # get BAU year
-    BAU_year = df_curtailment.filter(like="BAU", axis=1).columns.get_level_values(0)
+    BAU_year = df_hydrogen.filter(like="BAU", axis=1).columns.get_level_values(0)
 
-    fig, ax = plt.subplots(figsize=(7, 3))
-    for nice_name, color_code in color_codes.items():
-        if not nice_name == "BAU":
-            df_curtailment.loc["Total", (slice(None), nice_name)].plot(ax=ax, color=color_code, 
-                                                                       linewidth=2, marker='o', label=nice_name, zorder=5)
-        elif nice_name == "BAU" and not BAU_year.empty:
-            ax.axhline(y=df_curtailment.loc["Total", (BAU_year, nice_name)].values, 
-                       color=color_code, linestyle='--', label=nice_name, zorder=1)
+    for idx, output in figure_dict.items():
+        _, ax = plt.subplots(figsize=(7, 3))
+        for nice_name, color_code in color_codes.items():
+            if not nice_name == "BAU":
+                df_hydrogen.loc[idx, (slice(None), nice_name)].plot(ax=ax, color=color_code, 
+                                                                        linewidth=2, marker='o', label=nice_name, zorder=5)
+            elif nice_name == "BAU" and not BAU_year.empty:
+                ax.axhline(y=df_hydrogen.loc[idx, (BAU_year, nice_name)].values, 
+                        color=color_code, linestyle='--', label=nice_name, zorder=1)
 
-    unique_years = sorted(set(df_curtailment.columns.get_level_values(0)) - set(BAU_year))
-    ax.set_xticks(range(len(unique_years)))  # Set the tick locations
-    ax.set_xticklabels(unique_years)  # Set the tick labels
-    ax.set_ylabel("Curtailment [TWh]")
-    ax.set_xlabel(None)
-    ax.legend(loc="upper right", facecolor="white", fontsize='xx-small')
-    plt.savefig(snakemake.output.figure, dpi=600, bbox_inches = 'tight')
-    
+        unique_years = sorted(set(df_hydrogen.columns.get_level_values(0)) - set(BAU_year))
+        ax.set_xticks(range(len(unique_years)))  # Set the tick locations
+        ax.set_xticklabels(unique_years)  # Set the tick labels
+        ax.set_ylabel(idx)
+        ax.set_xlabel(None)
+        ax.legend(loc="upper left", facecolor="white", fontsize='xx-small')
+        plt.savefig(output, dpi=600, bbox_inches = 'tight')
+        
 
-def define_table_df(scenarios):
+def define_table_df(scenarios, idx):
     # Define column levels
     col_level_0 = ["2030"]*4 + ["2040"]*4 + ["2050"]*4
     col_level_1 = list(scenarios.values()) * 3
     # Create a MultiColumns
     multi_cols = pd.MultiIndex.from_arrays([col_level_0, col_level_1], names=['Year', 'Scenario'])
-    df = pd.DataFrame(columns=multi_cols, index=["Solar Rooftop PV", "Solar Utility PV", 
-                                                 "Onshore Wind", "Offshore Wind", "Total"])
+    df = pd.DataFrame(columns=multi_cols, index=idx)
     return df
 
 
@@ -115,9 +107,16 @@ if __name__ == "__main__":
                 "flexible-moderate": "Limited Renovation and Optimal Heating", 
                 "rigid": "No Renovation and Green Heating"}
 
+    # define dictionary to map to links buses
+    param_dict = {"Electricity used [TWh]": "p0",
+                  "Hydrogen produced [TWh]": "p1"}
+    
+    # define dictionary that contain snakemake outputs
+    figure_dict = {"Electricity used [TWh]": snakemake.output.figure_elec,
+                   "Hydrogen produced [TWh]": snakemake.output.figure_prod}
 
-    # initialize df for storing curtailment information
-    curtailment_df = define_table_df(scenarios)
+    # initialize df for storing hydrogen production information
+    hydrogen_df = define_table_df(scenarios, idx=param_dict.keys())
 
     for planning_horizon in planning_horizons:
         lineex = line_limits[planning_horizon]
@@ -132,8 +131,8 @@ if __name__ == "__main__":
                 print(f"Network is not found for scenario '{scenario}', planning year '{planning_horizon}', and time resolution of '{time_resolution}'. Skipping...")
                 continue
             
-            curtailment_dict = get_curtailment(n, nice_name)
-            curtailment_df.loc[:, (planning_horizon, nice_name)] = pd.Series(curtailment_dict)
+            hydrogen_dict = get_hydrogen_production(n, param_dict=param_dict)
+            hydrogen_df.loc[:, (planning_horizon, nice_name)] = pd.Series(hydrogen_dict)
     
     # Add BAU scenario
     BAU_horizon = BAU_HORIZON
@@ -147,15 +146,15 @@ if __name__ == "__main__":
         # Skip further computation for this scenario if network is not loaded
         print(f"Network is not found for scenario '{scenario}', planning year '{BAU_horizon}', and time resolution of '{time_resolution}'. Skipping...")
     else:
-        curtailment_dict = get_curtailment(n, scenario)
-        curtailment_df.loc[:, (BAU_horizon, scenario)] = pd.Series(curtailment_dict)
+        hydrogen_dict = get_hydrogen_production(n, param_dict=param_dict)
+        hydrogen_df.loc[:, (BAU_horizon, scenario)] = pd.Series(hydrogen_dict)
 
     # move to base directory
     change_path_to_base()
 
     # store to csv and png
-    if not curtailment_df.empty:
+    if not hydrogen_df.empty:
         # save to csv
-        curtailment_df.to_csv(snakemake.output.table)
+        hydrogen_df.to_csv(snakemake.output.table)
         # make plot
-        plot_curtailment(curtailment_df)
+        plot_hydrogen_production(hydrogen_df, figure_dict=figure_dict)

--- a/plots/plot_hydrogen_production.py
+++ b/plots/plot_hydrogen_production.py
@@ -98,7 +98,8 @@ if __name__ == "__main__":
     line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     opts = config["plotting"]["sector_opts"]
-    planning_horizons = ["2030", "2040", "2050"]
+    planning_horizons = config["plotting"]["planning_horizon"]
+    planning_horizons = [str(x) for x in planning_horizons if not str(x) == BAU_HORIZON]
     time_resolution = config["plotting"]["time_resolution"]
 
     # define scenario namings

--- a/plots/plot_total_costs.py
+++ b/plots/plot_total_costs.py
@@ -313,8 +313,8 @@ def plot_capacities(caps_df, clusters, planning_horizon, plot_width=7):
     ax.set_ylabel("Installed capacities [GW]")
 
     ax.set_xlabel("")
-    ax.set_ylim([0,15000])
-    ax.set_yticks(np.arange(0, 15000, 2000))
+    ax.set_ylim([0,19000])
+    ax.set_yticks(np.arange(0, 19000, 2000))
 
     # Turn off both horizontal and vertical grid lines
     ax.grid(False, which='both')

--- a/plots/plot_total_costs.py
+++ b/plots/plot_total_costs.py
@@ -178,7 +178,9 @@ def rename_techs(label):
 def compute_costs(n, nice_name, cost_type):
     assert cost_type in ["Operational", "Capital"], "Type variable must be 'Operational' or 'Capital'"
     # fix gas storage manually
-    n.stores.loc["EU gas Store", "e_nom_opt"] = n.stores_t.e["EU gas Store"].max()
+    n.stores.loc["EU gas Store", "e_nom_opt"] = (
+        n.stores_t.e["EU gas Store"].max() - n.stores_t.e["EU gas Store"].min()
+    )
     costs = n.statistics()[[f"{cost_type} Expenditure"]]
     new_index = [':'.join(idx) for idx in costs.index]
     costs.index = new_index

--- a/plots/plot_total_costs.py
+++ b/plots/plot_total_costs.py
@@ -424,6 +424,7 @@ if __name__ == "__main__":
     line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     planning_horizons = config["plotting"]["planning_horizon"]
+    planning_horizons = [str(x) for x in planning_horizons if not str(x) == BAU_HORIZON]
     time_resolution = config["plotting"]["time_resolution"]
     opts = config["plotting"]["sector_opts"]
 

--- a/plots/plot_total_costs.py
+++ b/plots/plot_total_costs.py
@@ -401,7 +401,8 @@ def define_table_df(scenarios):
 def fill_table_df(df, planning_horizon, scenarios, values):
     for scenario in scenarios.values():
         for tech_name, _ in values.iterrows():
-            df.loc[tech_name, (planning_horizon, scenario)] = values.loc[tech_name, scenario]
+            if scenario in values.columns:
+                df.loc[tech_name, (planning_horizon, scenario)] = values.loc[tech_name, scenario]
     return df
 
 

--- a/plots/plot_total_costs.py
+++ b/plots/plot_total_costs.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 RESULTS_DIR = "plots/results"
 
-DONT_PLOT = ["gas storage"]
+DONT_PLOT = []
 
 PREFIX_TO_REMOVE = [
     "residential ",
@@ -177,6 +177,8 @@ def rename_techs(label):
 
 def compute_costs(n, nice_name, cost_type):
     assert cost_type in ["Operational", "Capital"], "Type variable must be 'Operational' or 'Capital'"
+    # fix gas storage manually
+    n.stores.loc["EU gas Store", "e_nom_opt"] = n.stores_t.e["EU gas Store"].max()
     costs = n.statistics()[[f"{cost_type} Expenditure"]]
     new_index = [':'.join(idx) for idx in costs.index]
     costs.index = new_index
@@ -234,7 +236,7 @@ def plot_costs(cost_df, clusters, planning_horizon, plot_width=7):
     ax.set_ylabel("System Cost [EUR billion per year]")
 
     ax.set_xlabel("")
-    ax.set_ylim([0,1100])
+    ax.set_ylim([0,1200])
     ax.set_yticks(np.arange(0, 1100, 100))
 
     # Turn off both horizontal and vertical grid lines

--- a/plots/plot_total_costs.py
+++ b/plots/plot_total_costs.py
@@ -147,6 +147,7 @@ PREFERRED_ORDER = pd.Index(
         "ground heat pump",
         "gas boiler",
         "biomass boiler",
+        "WWHRS",
         "building retrofitting",
      ]
 )
@@ -205,7 +206,8 @@ def plot_costs(cost_df, clusters, planning_horizon, plot_width=7):
     )
 
     for remove_tech in DONT_PLOT:
-        new_index = new_index.drop(remove_tech)
+        if remove_tech in new_index:
+            new_index = new_index.drop(remove_tech)
 
     new_columns = df.sum().sort_values().index  
 

--- a/plots/table_heat_pumps.py
+++ b/plots/table_heat_pumps.py
@@ -8,7 +8,8 @@ import pandas as pd
 import warnings
 warnings.filterwarnings("ignore")
 from _helpers import mock_snakemake, update_config_from_wildcards, load_network, \
-                     change_path_to_pypsa_eur, change_path_to_base
+                     change_path_to_pypsa_eur, change_path_to_base, \
+                     LINE_LIMITS, CO2L_LIMITS
 
 
 def define_heat_pump_dataframe():
@@ -60,10 +61,11 @@ if __name__ == "__main__":
     # move to submodules/pypsa-eur
     change_path_to_pypsa_eur()
     # network parameters
-    co2l_limits = {"2030":"0.45", "2040":"0.1", "2050":"0.0"}
-    line_limits = {"2030":"v1.15", "2040":"v1.3", "2050":"v1.5"}
+    co2l_limits = CO2L_LIMITS
+    line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     time_resolution = config["plotting"]["time_resolution"]
+    opts = config["plotting"]["sector_opts"]
 
     # heat pump techs
     heat_pumps = {"residential": "Residential decentral", 
@@ -78,7 +80,7 @@ if __name__ == "__main__":
     scenarios = {"flexible": "Optimal Renovation and Heating", 
                  "retro_tes": "Optimal Renovation and Green Heating", 
                  "flexible-moderate": "Limited Renovation and Optimal Heating", 
-                 "rigid": "No Renovation and Optimal Heating"}
+                 "rigid": "No Renovation and Green Heating"}
 
     # define heat pumps dataframe
     df_heat_pumps = define_heat_pump_dataframe()
@@ -86,7 +88,7 @@ if __name__ == "__main__":
     # heat pumps estimation
     for planning_horizon in ["2030", "2040", "2050"]:
         lineex = line_limits[planning_horizon]
-        sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-T-H-B-I"
+        sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
 
         for scenario, nice_name in scenarios.items():
             # load networks

--- a/plots/table_heat_pumps.py
+++ b/plots/table_heat_pumps.py
@@ -9,7 +9,7 @@ import warnings
 warnings.filterwarnings("ignore")
 from _helpers import mock_snakemake, update_config_from_wildcards, load_network, \
                      change_path_to_pypsa_eur, change_path_to_base, \
-                     LINE_LIMITS, CO2L_LIMITS
+                     LINE_LIMITS, CO2L_LIMITS, BAU_HORIZON
 
 
 def define_heat_pump_dataframe():
@@ -65,6 +65,8 @@ if __name__ == "__main__":
     line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     time_resolution = config["plotting"]["time_resolution"]
+    planning_horizons = config["plotting"]["planning_horizon"]
+    planning_horizons = [str(x) for x in planning_horizons if not str(x) == BAU_HORIZON]
     opts = config["plotting"]["sector_opts"]
 
     # heat pump techs
@@ -86,7 +88,7 @@ if __name__ == "__main__":
     df_heat_pumps = define_heat_pump_dataframe()
 
     # heat pumps estimation
-    for planning_horizon in ["2030", "2040", "2050"]:
+    for planning_horizon in planning_horizons:
         lineex = line_limits[planning_horizon]
         sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
 

--- a/plots/table_infra_savings.py
+++ b/plots/table_infra_savings.py
@@ -9,7 +9,7 @@ import warnings
 warnings.filterwarnings("ignore")
 from _helpers import mock_snakemake, update_config_from_wildcards, load_network, \
                      change_path_to_pypsa_eur, change_path_to_base, \
-                     LINE_LIMITS, CO2L_LIMITS
+                     LINE_LIMITS, CO2L_LIMITS, BAU_HORIZON
                      
 from plot_total_costs import compute_costs
 
@@ -31,6 +31,8 @@ if __name__ == "__main__":
     line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     time_resolution = config["plotting"]["time_resolution"]
+    planning_horizons = config["plotting"]["planning_horizon"]
+    planning_horizons = [str(x) for x in planning_horizons if not str(x) == BAU_HORIZON]
     opts = config["plotting"]["sector_opts"]
 
     # define scenario namings
@@ -59,7 +61,7 @@ if __name__ == "__main__":
     df_savings.columns = pd.MultiIndex.from_tuples(df_savings.columns, names=['horizon','tech'])
     cost_savings.columns = pd.MultiIndex.from_tuples(cost_savings.columns, names=['horizon','tech'])
 
-    for planning_horizon in ["2030", "2040", "2050"]:
+    for planning_horizon in planning_horizons:
         lineex = line_limits[planning_horizon]
         sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
 

--- a/plots/table_infra_savings.py
+++ b/plots/table_infra_savings.py
@@ -8,7 +8,9 @@ import pandas as pd
 import warnings
 warnings.filterwarnings("ignore")
 from _helpers import mock_snakemake, update_config_from_wildcards, load_network, \
-                     change_path_to_pypsa_eur, change_path_to_base
+                     change_path_to_pypsa_eur, change_path_to_base, \
+                     LINE_LIMITS, CO2L_LIMITS
+                     
 from plot_total_costs import compute_costs
 
 
@@ -25,10 +27,11 @@ if __name__ == "__main__":
     # move to submodules/pypsa-eur
     change_path_to_pypsa_eur()
     # network parameters
-    co2l_limits = {"2030":"0.45", "2040":"0.1", "2050":"0.0"}
-    line_limits = {"2030":"v1.15", "2040":"v1.3", "2050":"v1.5"}
+    co2l_limits = CO2L_LIMITS
+    line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     time_resolution = config["plotting"]["time_resolution"]
+    opts = config["plotting"]["sector_opts"]
 
     # define scenario namings
     scenarios = {"flexible": "Optimal Renovation and Heating", 
@@ -58,7 +61,7 @@ if __name__ == "__main__":
 
     for planning_horizon in ["2030", "2040", "2050"]:
         lineex = line_limits[planning_horizon]
-        sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-T-H-B-I"
+        sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
 
         # benchmark network
         b = load_network(lineex, clusters, sector_opts, planning_horizon, "rigid")

--- a/plots/table_line_congestion.py
+++ b/plots/table_line_congestion.py
@@ -8,7 +8,8 @@ import pandas as pd
 import warnings
 warnings.filterwarnings("ignore")
 from _helpers import mock_snakemake, update_config_from_wildcards, load_network, \
-                     change_path_to_pypsa_eur, change_path_to_base
+                     change_path_to_pypsa_eur, change_path_to_base, \
+                     LINE_LIMITS, CO2L_LIMITS
 
 
 if __name__ == "__main__":
@@ -24,10 +25,11 @@ if __name__ == "__main__":
     # move to submodules/pypsa-eur
     change_path_to_pypsa_eur()
     # network parameters
-    co2l_limits = {"2030":"0.45", "2040":"0.1", "2050":"0.0"}
-    line_limits = {"2030":"v1.15", "2040":"v1.3", "2050":"v1.5"}
+    co2l_limits = CO2L_LIMITS
+    line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     time_resolution = config["plotting"]["time_resolution"]
+    opts = config["plotting"]["sector_opts"]
 
     # define scenario namings
     scenarios = {"flexible": "Optimal Renovation and Heating", 
@@ -41,7 +43,7 @@ if __name__ == "__main__":
     # line congestion estimation
     for planning_horizon in ["2030", "2040", "2050"]:
         lineex = line_limits[planning_horizon]
-        sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-T-H-B-I"
+        sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
 
         for scenario, nice_name in scenarios.items():
             # load networks

--- a/plots/table_line_congestion.py
+++ b/plots/table_line_congestion.py
@@ -9,7 +9,7 @@ import warnings
 warnings.filterwarnings("ignore")
 from _helpers import mock_snakemake, update_config_from_wildcards, load_network, \
                      change_path_to_pypsa_eur, change_path_to_base, \
-                     LINE_LIMITS, CO2L_LIMITS
+                     LINE_LIMITS, CO2L_LIMITS, BAU_HORIZON
 
 
 if __name__ == "__main__":
@@ -29,6 +29,8 @@ if __name__ == "__main__":
     line_limits = LINE_LIMITS
     clusters = config["plotting"]["clusters"]
     time_resolution = config["plotting"]["time_resolution"]
+    planning_horizons = config["plotting"]["planning_horizon"]
+    planning_horizons = [str(x) for x in planning_horizons if not str(x) == BAU_HORIZON]
     opts = config["plotting"]["sector_opts"]
 
     # define scenario namings
@@ -41,7 +43,7 @@ if __name__ == "__main__":
     df_congestion = pd.DataFrame(index=list(scenarios.values()), columns=["2030", "2040", "2050"])
 
     # line congestion estimation
-    for planning_horizon in ["2030", "2040", "2050"]:
+    for planning_horizon in planning_horizons:
         lineex = line_limits[planning_horizon]
         sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
 

--- a/scripts/moderate_retrofitting.py
+++ b/scripts/moderate_retrofitting.py
@@ -62,9 +62,9 @@ if __name__ == "__main__":
             success = True
         except Exception as e:
             print(f"Error: {e}")
-            success = False
+            raise FileNotFoundError("File was not saved")
     else:
-        success = False
+        raise FileNotFoundError("Missing input network")
 
     # move to base directory
     change_path_to_base()

--- a/scripts/moderate_retrofitting.py
+++ b/scripts/moderate_retrofitting.py
@@ -6,17 +6,17 @@ import warnings
 warnings.filterwarnings("ignore")
 from plots._helpers import mock_snakemake, update_config_from_wildcards, load_network, \
                     change_path_to_pypsa_eur, change_path_to_base, load_unsolved_network, \
-                    save_unsolved_network
+                    save_unsolved_network, CO2L_LIMITS, LINE_LIMITS
 
 
 def set_moderate_retrofitting(n_solved, n_unsolved):
     # get optimal retrofitting from the solved network
     retro_opt = n_solved.generators.query("carrier in 'retrofitting'")[["p_nom_opt"]]
     retro_data = retro_opt / 2
-    # set p_nom as half of p_nom_opt of flexible scenario
-    n_unsolved.generators.loc[retro_data.index, "p_nom"] = retro_data["p_nom_opt"]
+    # set p_nom_max as half of p_nom_opt of flexible scenario
+    n_unsolved.generators.loc[retro_data.index, "p_nom_max"] = retro_data["p_nom_opt"].combine(n_unsolved.generators.loc[retro_data.index, "p_nom_min"], max)
     # set retrofitting not extendable
-    n_unsolved.generators.loc[retro_data.index, "p_nom_extendable"] = False
+    n_unsolved.generators.loc[retro_data.index, "p_nom_extendable"] = True
 
     return n_unsolved
 
@@ -32,15 +32,16 @@ if __name__ == "__main__":
     config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
 
     # network parameters by year
-    co2l_limits = {"2030":"0.45", "2040":"0.1", "2050":"0.0"}
-    line_limits = {"2030":"v1.15", "2040":"v1.3", "2050":"v1.5"}
+    co2l_limits = CO2L_LIMITS
+    line_limits = LINE_LIMITS
 
     # network parameters of unsolved network
     clusters = config["moderate_retrofitting"]["clusters"]
     planning_horizon = config["moderate_retrofitting"]["planning_horizon"]
     time_resolution = config["moderate_retrofitting"]["time_resolution"]
+    opts = config["moderate_retrofitting"]["sector_opts"]
     lineex = line_limits[planning_horizon]
-    sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-T-H-B-I"
+    sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
 
     # move to pypsa-eur directory
     change_path_to_pypsa_eur()

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -91,7 +91,7 @@ def prepare_prenetwork(scenario, horizon):
     # get .nc filename
     filename = get_network_name(scenario, horizon)
     # run prenetwork
-    command = f"snakemake --cores 2 results/{scenario}/prenetworks/{filename} --configfile {config_path} --force"
+    command = f"snakemake -call results/{scenario}/prenetworks/{filename} --configfile {config_path} --force"
     subprocess.run(command, shell=True)
     logging.info(f"Prenetwork was prepared for {scenario} scenario in {horizon} horizon!")
 
@@ -125,7 +125,7 @@ def solve_network(scenario, horizon):
     change_path_to_pypsa_eur()
 
     # solve the network
-    command = f"snakemake --cores 2 solve_sector_networks --configfile {config_path}"
+    command = f"snakemake -call solve_sector_networks --configfile {config_path}"
     subprocess.run(command, shell=True)
     logging.info(f"Network was solved for {scenario} scenario in {horizon} horizon!")
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -219,6 +219,9 @@ if __name__ == "__main__":
             increase_biomass_potential()
         # run prenetwork
         prepare_prenetwork(scenario=scenario, horizon=horizon)
+
+        # initialize error_capacities and error_moderate
+        error_capacities, error_moderate = [], []
         
         # set capacities if 2040 or 2050
         if not horizon == 2030:

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
         prepare_prenetwork(scenario=scenario, horizon=horizon)
         
         # set capacities if 2040 or 2050
-        if not horizon == "2030":
+        if not horizon == 2030:
             set_capacities(scenario=scenario, horizon=horizon)
 
         # set moderate retrofitting

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,0 +1,158 @@
+import subprocess
+import argparse
+import logging
+import yaml
+import sys
+sys.path.append("plots")
+from _helpers import change_path_to_pypsa_eur, change_path_to_base
+
+# Set up logging configuration
+logging.basicConfig(level=logging.INFO)
+
+def get_scenario():
+    parser = argparse.ArgumentParser(description="Running the scenario")
+    parser.add_argument("-s", "--scenario", help="Specify the scenario.", required=True, 
+                        choices=["flexible", "flexible-moderate", "retro_tes", "rigid"])
+    parser.add_argument("-c", "--continue_horizon", help="Specify the horizon to continue simulations", 
+                        choices=["2030", "2040", "2050"])
+    args = parser.parse_args()
+
+    # Access the value of the scenario argument
+    scenario = args.scenario
+    # log scenario name
+    logging.info(f"Scenario: {scenario}")
+
+    # Access the value of the horizon argument
+    c = int(args.continue_horizon)
+    # log scenario name
+    if c:
+        logging.info(f"Start simulating from {c}")
+    else:
+        c = 2030
+        logging.info("No horizon specified. Starting from default horizon (2030)")
+
+    return scenario, c
+
+
+def get_horizon_list(start_horizon):
+    horizons = [2030, 2040, 2050]
+    try:
+        start_index = horizons.index(start_horizon)
+        return horizons[start_index:]
+    except ValueError:
+        return []
+
+
+def get_clusters(scenario, horizon):
+    config_path = get_config_path(scenario, horizon)
+    # read config file
+    with open(config_path, 'r') as file:
+        config = yaml.safe_load(file)
+    return config["scenario"]["clusters"][0]
+
+
+def get_config_path(scenario, horizon):
+    configname_dict = {"flexible": "flexible-industry",
+                       "flexible-moderate": "flexible-moderate",
+                       "retro_tes": "retro_tes-industry",
+                       "rigid": "rigid-industry"}
+    configname = f"config.{configname_dict[scenario]}_{horizon}.yaml"
+    configpath = "configs/EEE_study/"
+    return configpath + configname
+
+
+def get_network_name(scenario, horizon):
+    config_path = get_config_path(scenario, horizon)
+    config_path = "../../" + config_path
+    # read config file
+    with open(config_path, 'r') as file:
+        config = yaml.safe_load(file)
+    # read config.default.yaml file
+    with open("config/config.default.yaml", 'r') as file:
+        config_default = yaml.safe_load(file)
+    # scenario params
+    params = config["scenario"]
+    params_default = config_default["scenario"]
+    ll, clusters, sector_opts, planning_horizons = params['ll'][0], params['clusters'][0], params['sector_opts'][0], params['planning_horizons'][0]
+    simpl, opts = params_default['simpl'][0], params_default['opts'][0]
+    filename = f"elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc"
+    return filename
+
+
+def prepare_prenetwork(scenario, horizon):
+    # get config path
+    config_path = get_config_path(scenario, horizon)
+    # config path relative to pypsa-eur folder
+    config_path = "../../" + config_path
+
+    # change path to pypsa-eur
+    change_path_to_pypsa_eur()
+
+    # get .nc filename
+    filename = get_network_name(scenario, horizon)
+    # run prenetwork
+    command = f"snakemake --cores 2 results/{scenario}/prenetworks/{filename} --configfile {config_path} --force"
+    subprocess.run(command, shell=True)
+    logging.info(f"Prenetwork was prepared for {scenario} scenario in {horizon} horizon!")
+
+    # move to base directory
+    change_path_to_base()
+
+
+def set_capacities(scenario, horizon):
+    # get number of clusters
+    clusters = get_clusters(scenario, horizon)
+    command = f"snakemake -call scripts/logs/set_capacities_{clusters}_{horizon}_{scenario}.txt --forceall"
+    subprocess.run(command, shell=True)
+    logging.info(f"Capacities are set to {scenario} scenario in {horizon} horizon!")
+
+
+def moderate_retrofitting(scenario, horizon):
+    # get number of clusters
+    clusters = get_clusters(scenario, horizon)
+    command = f"snakemake -call scripts/logs/set_moderate_retrofitting_{clusters}_{horizon}.txt --forceall"
+    subprocess.run(command, shell=True)
+    logging.info(f"Moderate retrofitting capacities are set to {scenario} scenario in {horizon} horizon!")
+
+
+def solve_network(scenario, horizon):
+    # get config path
+    config_path = get_config_path(scenario, horizon)
+    # config path relative to pypsa-eur folder
+    config_path = "../../" + config_path
+
+    # change path to pypsa-eur
+    change_path_to_pypsa_eur()
+
+    # solve the network
+    command = f"snakemake --cores 2 solve_sector_networks --configfile {config_path}"
+    subprocess.run(command, shell=True)
+    logging.info(f"Network was solved for {scenario} scenario in {horizon} horizon!")
+
+    # move to base directory
+    change_path_to_base()
+
+
+if __name__ == "__main__":
+    # get scenario from argument
+    scenario, start_horizon = get_scenario()
+    # scenario, start_horizon = "rigid", 2050
+    # horizons to be simulated
+    horizons = get_horizon_list(start_horizon=start_horizon)
+
+    # run model for given horizon
+    for horizon in horizons:
+        # run prenetwork
+        prepare_prenetwork(scenario=scenario, horizon=horizon)
+        
+        # set capacities if 2040 or 2050
+        if not horizon == "2030":
+            set_capacities(scenario=scenario, horizon=horizon)
+
+        # set moderate retrofitting
+        if scenario == "flexible-moderate":
+            moderate_retrofitting(scenario=scenario, horizon=horizon)
+
+        # solve the network
+        solve_network(scenario, horizon)
+

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -136,7 +136,7 @@ def solve_network(scenario, horizon):
 if __name__ == "__main__":
     # get scenario from argument
     scenario, start_horizon = get_scenario()
-    # scenario, start_horizon = "rigid", 2050
+
     # horizons to be simulated
     horizons = get_horizon_list(start_horizon=start_horizon)
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -15,6 +15,8 @@ def get_scenario():
                         choices=["flexible", "flexible-moderate", "retro_tes", "rigid"])
     parser.add_argument("-c", "--continue_horizon", help="Specify the horizon to continue simulations", 
                         choices=["2030", "2040", "2050"])
+    parser.add_argument("-y", "--year", help="Specify a single horizon to simulate", 
+                        choices=["2030", "2040", "2050"])
     args = parser.parse_args()
 
     # Access the value of the scenario argument
@@ -22,16 +24,24 @@ def get_scenario():
     # log scenario name
     logging.info(f"Scenario: {scenario}")
 
-    # Access the value of the horizon argument
+    # Access the value of horizon from which simulation is continued
     c = args.continue_horizon
+    # Access the value of specific horizon to simulate
+    y = args.year
+
     # log scenario name
-    if c:
-        logging.info(f"Start simulating from {c}")
+    if y:
+        horizons = [int(y)]
+        logging.info(f"Start simulating {scenario} scenario for {y}")
+    elif c:
+        horizons = get_horizon_list(int(c))
+        logging.info(f"Start simulating {scenario} scenario for {horizons}")
     else:
         c = 2030
+        horizons = get_horizon_list(int(c))
         logging.info("No horizon specified. Starting from default horizon (2030)")
 
-    return scenario, int(c)
+    return scenario, horizons
 
 
 def get_horizon_list(start_horizon):
@@ -208,10 +218,7 @@ def solve_network(scenario, horizon):
 
 if __name__ == "__main__":
     # get scenario from argument
-    scenario, start_horizon = get_scenario()
-
-    # horizons to be simulated
-    horizons = get_horizon_list(start_horizon=start_horizon)
+    scenario, horizons = get_scenario()
 
     # run model for given horizon
     for horizon in horizons:

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -23,7 +23,7 @@ def get_scenario():
     logging.info(f"Scenario: {scenario}")
 
     # Access the value of the horizon argument
-    c = int(args.continue_horizon)
+    c = args.continue_horizon
     # log scenario name
     if c:
         logging.info(f"Start simulating from {c}")
@@ -31,7 +31,7 @@ def get_scenario():
         c = 2030
         logging.info("No horizon specified. Starting from default horizon (2030)")
 
-    return scenario, c
+    return scenario, int(c)
 
 
 def get_horizon_list(start_horizon):

--- a/scripts/set_capacities.py
+++ b/scripts/set_capacities.py
@@ -65,8 +65,8 @@ def set_optimal_capacities(solved_network, unsolved_network):
 
     # set p_nom_max as max of p_nom_min and p_nom_max
     unsolved_network.generators.loc[target_gens, "p_nom_max"] = unsolved_network.generators.loc[target_gens, ["p_nom_min", "p_nom_max"]].max(axis=1)
-    unsolved_network.stores.loc[target_stores, "e_nom_min"] = unsolved_network.stores.loc[target_stores, ["e_nom_min", "e_nom_max"]].max(axis=1)
-    unsolved_network.links.loc[target_links, "p_nom_min"] = unsolved_network.links.loc[target_links, ["p_nom_min", "p_nom_max"]].max(axis=1)
+    unsolved_network.stores.loc[target_stores, "e_nom_max"] = unsolved_network.stores.loc[target_stores, ["e_nom_min", "e_nom_max"]].max(axis=1)
+    unsolved_network.links.loc[target_links, "p_nom_max"] = unsolved_network.links.loc[target_links, ["p_nom_min", "p_nom_max"]].max(axis=1)
 
     # set p_nom_max as max(p_nom_max, p_nom_min) for retrofitting
     retro_idx = unsolved_network.generators.query("carrier == 'retrofitting'").index

--- a/scripts/set_capacities.py
+++ b/scripts/set_capacities.py
@@ -11,6 +11,10 @@ from plots._helpers import mock_snakemake, update_config_from_wildcards, load_ne
                     save_unsolved_network, LINE_LIMITS, CO2L_LIMITS
 
 
+class CustomError(Exception):
+    pass
+
+
 def get_capacities(network, capacity="opt"):
     # extendable generators and capacities
     ext_gen = network.generators.query("p_nom_extendable==True")
@@ -124,9 +128,9 @@ if __name__ == "__main__":
             success = True
         except Exception as e:
             print(f"Error: {e}")
-            success = False
+            raise FileNotFoundError("File was not saved")
     else:
-        success = False
+        raise FileNotFoundError("Missing input network")
 
     # move to base directory
     change_path_to_base()

--- a/scripts/set_capacities.py
+++ b/scripts/set_capacities.py
@@ -8,7 +8,7 @@ import warnings
 warnings.filterwarnings("ignore")
 from plots._helpers import mock_snakemake, update_config_from_wildcards, load_network, \
                     change_path_to_pypsa_eur, change_path_to_base, load_unsolved_network, \
-                    save_unsolved_network
+                    save_unsolved_network, LINE_LIMITS, CO2L_LIMITS
 
 
 def get_capacities(network, capacity="opt"):
@@ -82,8 +82,8 @@ if __name__ == "__main__":
     config = update_config_from_wildcards(snakemake.config, snakemake.wildcards)
 
     # network parameters by year
-    co2l_limits = {"2030":"0.45", "2040":"0.1", "2050":"0.0"}
-    line_limits = {"2030":"v1.15", "2040":"v1.3", "2050":"v1.5"}
+    co2l_limits = CO2L_LIMITS
+    line_limits = LINE_LIMITS
     previous_horizons = {"2040":"2030", "2050":"2040"} 
 
     # network parameters of unsolved network
@@ -91,13 +91,14 @@ if __name__ == "__main__":
     planning_horizon = config["set_capacities"]["planning_horizon"]
     time_resolution = config["set_capacities"]["time_resolution"]
     scenario = config["set_capacities"]["scenario"]
+    opts = config["set_capacities"]["sector_opts"]
     lineex = line_limits[planning_horizon]
-    sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-dist1.1-T-H-B-I"
+    sector_opts = f"Co2L{co2l_limits[planning_horizon]}-{time_resolution}-{opts}"
 
     # network parameters of solved network
     previous_horizon = previous_horizons[planning_horizon]
     previous_lineex = line_limits[previous_horizon]
-    previous_sector_opts = f"Co2L{co2l_limits[previous_horizon]}-{time_resolution}-dist1.1-T-H-B-I"
+    previous_sector_opts = f"Co2L{co2l_limits[previous_horizon]}-{time_resolution}-{opts}"
 
     # move to pypsa-eur directory
     change_path_to_pypsa_eur()

--- a/scripts/set_capacities.py
+++ b/scripts/set_capacities.py
@@ -63,6 +63,11 @@ def set_optimal_capacities(solved_network, unsolved_network):
     unsolved_network.stores.loc[target_stores, "e_nom_min"] = opt_store_cap[target_stores]
     unsolved_network.links.loc[target_links, "p_nom_min"] = opt_link_cap[target_links]
 
+    # set p_nom_max as max of p_nom_min and p_nom_max
+    unsolved_network.generators.loc[target_gens, "p_nom_max"] = unsolved_network.generators.loc[target_gens, ["p_nom_min", "p_nom_max"]].max(axis=1)
+    unsolved_network.stores.loc[target_stores, "e_nom_min"] = unsolved_network.stores.loc[target_stores, ["e_nom_min", "e_nom_max"]].max(axis=1)
+    unsolved_network.links.loc[target_links, "p_nom_min"] = unsolved_network.links.loc[target_links, ["p_nom_min", "p_nom_max"]].max(axis=1)
+
     # set p_nom_max as max(p_nom_max, p_nom_min) for retrofitting
     retro_idx = unsolved_network.generators.query("carrier == 'retrofitting'").index
     unsolved_network.generators.loc[retro_idx, "p_nom_max"] = unsolved_network.generators.loc[retro_idx, ["p_nom_max", "p_nom_min"]].max(axis=1)


### PR DESCRIPTION
Good day. This PR is a complex PR touching different aspects. It is focused on updating plots by adding BAU scenario. In addition, `mock_snakemake` was fixed to accommodate debugging. In addition, new plots are being added to the repository. The following tasks are being addressed:

- [x] Add BAU scenario to `plot_total_costs` plots
- [x] Add BAU scenario to `plot_electricity_bills` plots
- [x] Add BAU scenario to `plot_curtailment` plot and table
- [x] Add BAU scenario for `plot_elec_generation` plots
- [x] Fix `moderate_retrofitting` script to make sure `p_nom_opt`/2 (previous) == `p_nom_max` (current) and `p_nom_extendable=True`. Also `p_nom_max` > `p_nom_min`
- [x] Fix `set_capacities` script to make sure `p_nom_max` = max(`p_nom_max`,`p_nom_min`)
- [x] Add wrapper script `run.py` to run all horizons of one scenario with one command
- [x] Add instruction to use `run.py` to the `README`
- [x] Add nuclear, lignite, coal generation to `plot_elec_generation` plots 
- [x] Add plots for hydrogen production for all planning horizons, scenarios
- [x] Add plots for proportion of heat pumps / resistive heaters / gas boilers (MW_el capacity)
- [x] Add total generation in TWh to `plot_electricity_generation` plots
- [ ] Add plots for electricity demand for all years (note: heating demand is non-electric, it's just supplied by electricity)
- [x] Add Co2 plot over time / totals
- [x] Add plots of COP for heat pumps and seasonal coefficient
- [x] Update `plot_electricity_bills` by adding gas cost from previously defined mCHP, gas boilers, and newly defined gas CHPs
- [x] Update `set_capacities` script by removing `p_nom_min` assignment from `p_nom_opt` and setting `p_nom_max` instead.
- [ ] Update `plot_CO2_levels` script to add energy balance plot with clean and rearranged legend
- [ ]  