### PR TITLE
Remove cost factors of 2 for retrofitting

### DIFF
--- a/configs/EEE_study/config.flexible-industry_2040.yaml
+++ b/configs/EEE_study/config.flexible-industry_2040.yaml
@@ -56,7 +56,6 @@ sector:
     retro_endogen: true
     WWHR_endogen: true
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: true
   boilers: true
   biomass_boiler: false

--- a/configs/EEE_study/config.flexible-industry_2050.yaml
+++ b/configs/EEE_study/config.flexible-industry_2050.yaml
@@ -56,7 +56,6 @@ sector:
     retro_endogen: true
     WWHR_endogen: true
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: true
   boilers: true
   biomass_boiler: false

--- a/configs/EEE_study/config.flexible-moderate_2030.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2030.yaml
@@ -56,7 +56,6 @@ sector:
     retro_endogen: true
     WWHR_endogen: true
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: true
   boilers: true
   biomass_boiler: false

--- a/configs/EEE_study/config.flexible-moderate_2040.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2040.yaml
@@ -56,7 +56,6 @@ sector:
     retro_endogen: true
     WWHR_endogen: true
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: true
   boilers: false
   biomass_boiler: false

--- a/configs/EEE_study/config.flexible-moderate_2050.yaml
+++ b/configs/EEE_study/config.flexible-moderate_2050.yaml
@@ -56,7 +56,6 @@ sector:
     retro_endogen: true
     WWHR_endogen: true
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: true
   boilers: false
   biomass_boiler: false

--- a/configs/EEE_study/config.retro_tes-industry_2030.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2030.yaml
@@ -56,7 +56,6 @@ sector:
     retro_endogen: true
     WWHR_endogen: true
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.retro_tes-industry_2040.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2040.yaml
@@ -56,7 +56,6 @@ sector:
     retro_endogen: true
     WWHR_endogen: true
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.retro_tes-industry_2050.yaml
+++ b/configs/EEE_study/config.retro_tes-industry_2050.yaml
@@ -56,7 +56,6 @@ sector:
     retro_endogen: true
     WWHR_endogen: true
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.rigid-industry_2030.yaml
+++ b/configs/EEE_study/config.rigid-industry_2030.yaml
@@ -54,7 +54,6 @@ sector:
     retro_endogen: false
     WWHR_endogen: false
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: false #true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.rigid-industry_2040.yaml
+++ b/configs/EEE_study/config.rigid-industry_2040.yaml
@@ -54,7 +54,6 @@ sector:
     retro_endogen: false
     WWHR_endogen: false
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: false #true
   boilers: false #true
   biomass_boiler: false

--- a/configs/EEE_study/config.rigid-industry_2050.yaml
+++ b/configs/EEE_study/config.rigid-industry_2050.yaml
@@ -54,7 +54,6 @@ sector:
     retro_endogen: false
     WWHR_endogen: false
     weighting_by_building_types: true # true weights AB, SFH and MFH
-    cost_factor: 2
   tes: false # true
   boilers: false #true
   biomass_boiler: false


### PR DESCRIPTION
Good day. Here, I propose to remove `cost_factor: 2.0` for building retrofitting that was occasionally set to config files. 